### PR TITLE
Refactor to provide custom implementation of vault context path building

### DIFF
--- a/spring-cloud-vault-config/src/main/java/org/springframework/cloud/vault/config/DefaultVaultPropertySourceContextStrategy.java
+++ b/spring-cloud-vault-config/src/main/java/org/springframework/cloud/vault/config/DefaultVaultPropertySourceContextStrategy.java
@@ -1,0 +1,81 @@
+package org.springframework.cloud.vault.config;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
+
+/**
+ * Default implementation of the {@link VaultPropertySourceContextStrategy} that generates the
+ * following vault paths to search for configuration values:
+ * <ol>
+ *   <li>/{backend}/{application}/{profile}</li>
+ *   <li>/{backend}/{application}</li>
+ *   <li>/{backend}/{defaultContext}/{profile}</li>
+ *   <li>/{backend}/{defaultContext}</li>
+ * </ol>
+ *
+ * @author Spencer Gibb
+ * @author Mark Paluch
+ * @author Jean-Philippe Bélanger
+ * @author Jonathan Pearlin
+ */
+public class DefaultVaultPropertySourceContextStrategy implements VaultPropertySourceContextStrategy {
+
+    private final VaultGenericBackendProperties genericBackendProperties;
+
+    /**
+     * Creates a new {@link DefaultVaultPropertySourceContextStrategy}.
+     *
+     * @param genericBackendProperties must not be {@literal null}.
+     */
+    public DefaultVaultPropertySourceContextStrategy(final VaultGenericBackendProperties genericBackendProperties) {
+        Assert.notNull(genericBackendProperties,
+                "VaultGenericBackendProperties must not be null");
+
+        this.genericBackendProperties = genericBackendProperties;
+    }
+
+    @Override
+    public List<String> buildContexts(final ConfigurableEnvironment env) {
+        final String appName = env.getProperty("spring.application.name");
+        final List<String> profiles = Arrays.asList(env.getActiveProfiles());
+        final List<String> contexts = new ArrayList<>();
+
+        final String defaultContext = genericBackendProperties.getDefaultContext();
+        if (StringUtils.hasText(defaultContext)) {
+            contexts.add(defaultContext);
+        }
+
+        addProfiles(contexts, defaultContext, profiles);
+
+        if (StringUtils.hasText(appName)) {
+
+            if (!contexts.contains(appName)) {
+                contexts.add(appName);
+            }
+
+            addProfiles(contexts, appName, profiles);
+        }
+
+        Collections.reverse(contexts);
+        return contexts;
+    }
+
+    private void addProfiles(final List<String> contexts, final String baseContext,
+            final List<String> profiles) {
+
+        for (final String profile : profiles) {
+            final String context = baseContext
+                    + this.genericBackendProperties.getProfileSeparator() + profile;
+
+            if (!contexts.contains(context)) {
+                contexts.add(context);
+            }
+        }
+    }
+}

--- a/spring-cloud-vault-config/src/main/java/org/springframework/cloud/vault/config/LeasingVaultPropertySourceLocator.java
+++ b/spring-cloud-vault-config/src/main/java/org/springframework/cloud/vault/config/LeasingVaultPropertySourceLocator.java
@@ -50,16 +50,18 @@ class LeasingVaultPropertySourceLocator extends VaultPropertySourceLocator
 	 * @param operations must not be {@literal null}.
 	 * @param properties must not be {@literal null}.
 	 * @param genericBackendProperties must not be {@literal null}.
+	 * @param vaultPropertySourceContextStrategy must not be {@literal null}.
 	 * @param backendAccessors must not be {@literal null}.
 	 * @param taskScheduler must not be {@literal null}.
 	 */
 	public LeasingVaultPropertySourceLocator(VaultConfigOperations operations,
 			VaultProperties properties,
 			VaultGenericBackendProperties genericBackendProperties,
+			VaultPropertySourceContextStrategy vaultPropertySourceContextStrategy,
 			Collection<SecretBackendMetadata> backendAccessors,
 			TaskScheduler taskScheduler) {
 
-		super(operations, properties, genericBackendProperties, backendAccessors);
+		super(operations, properties, genericBackendProperties, vaultPropertySourceContextStrategy, backendAccessors);
 
 		Assert.notNull(taskScheduler, "TaskScheduler must not be null");
 		Assert.notNull(operations, "VaultConfigTemplate must not be null");

--- a/spring-cloud-vault-config/src/main/java/org/springframework/cloud/vault/config/VaultBootstrapConfiguration.java
+++ b/spring-cloud-vault-config/src/main/java/org/springframework/cloud/vault/config/VaultBootstrapConfiguration.java
@@ -84,10 +84,17 @@ public class VaultBootstrapConfiguration implements InitializingBean {
 	}
 
 	@Bean
+	@ConditionalOnMissingBean
+	public VaultPropertySourceContextStrategy vaultPropertySourceContextStrategy(VaultGenericBackendProperties vaultGenericBackendProperties) {
+		return new DefaultVaultPropertySourceContextStrategy(vaultGenericBackendProperties);
+	}
+
+	@Bean
 	public VaultPropertySourceLocator vaultPropertySourceLocator(
 			VaultOperations operations,
 			VaultProperties vaultProperties,
 			VaultGenericBackendProperties vaultGenericBackendProperties,
+			VaultPropertySourceContextStrategy vaultPropertySourceContextStrategy,
 			ObjectFactory<TaskSchedulerWrapper<? extends TaskScheduler>> taskSchedulerFactory) {
 
 		Collection<SecretBackendMetadata> backendAccessors = SecretBackendFactories
@@ -102,12 +109,12 @@ public class VaultBootstrapConfiguration implements InitializingBean {
 			applicationContext.registerShutdownHook();
 
 			return new LeasingVaultPropertySourceLocator(vaultConfigTemplate,
-					vaultProperties, vaultGenericBackendProperties, backendAccessors,
+					vaultProperties, vaultGenericBackendProperties, vaultPropertySourceContextStrategy, backendAccessors,
 					taskSchedulerFactory.getObject().getTaskScheduler());
 		}
 
 		return new VaultPropertySourceLocator(vaultConfigTemplate, vaultProperties,
-				vaultGenericBackendProperties, backendAccessors);
+				vaultGenericBackendProperties, vaultPropertySourceContextStrategy, backendAccessors);
 	}
 
 	/**

--- a/spring-cloud-vault-config/src/main/java/org/springframework/cloud/vault/config/VaultPropertySourceContextStrategy.java
+++ b/spring-cloud-vault-config/src/main/java/org/springframework/cloud/vault/config/VaultPropertySourceContextStrategy.java
@@ -1,0 +1,22 @@
+package org.springframework.cloud.vault.config;
+
+import java.util.List;
+
+import org.springframework.core.env.ConfigurableEnvironment;
+
+/**
+ * Defines a strategy for building the list of Vault contexts to be searched
+ * by the {@link VaultPropertySourceLocator} for configuration.
+ *
+ * @author Jonathan Pearlin
+ */
+public interface VaultPropertySourceContextStrategy {
+
+    /**
+     * Builds the Vault context paths used by the {@link VaultPropertySourceLocator}
+     * to search for configuration.
+     * @param env The selected Spring environment.
+     * @return The list of Vault context paths.
+     */
+    List<String> buildContexts(ConfigurableEnvironment env);
+}

--- a/spring-cloud-vault-config/src/test/java/org/springframework/cloud/vault/config/LeasingVaultPropertySourceLocatorUnitTests.java
+++ b/spring-cloud-vault-config/src/test/java/org/springframework/cloud/vault/config/LeasingVaultPropertySourceLocatorUnitTests.java
@@ -55,11 +55,15 @@ public class LeasingVaultPropertySourceLocatorUnitTests {
 	@Mock
 	private LeasingVaultPropertySource leasingVaultPropertySource;
 
+    @Mock
+    private VaultPropertySourceContextStrategy vaultPropertySourceContextStrategy;
+
 	@Before
 	public void before() {
 
 		propertySourceLocator = new LeasingVaultPropertySourceLocator(operations,
-				new VaultProperties(), new VaultGenericBackendProperties(),
+				new VaultProperties(), new VaultGenericBackendProperties(), 
+				vaultPropertySourceContextStrategy,
 				Collections.<SecretBackendMetadata> emptyList(), taskScheduler);
 	}
 
@@ -71,6 +75,7 @@ public class LeasingVaultPropertySourceLocatorUnitTests {
 
 		propertySourceLocator = new LeasingVaultPropertySourceLocator(operations,
 				vaultProperties, new VaultGenericBackendProperties(),
+				vaultPropertySourceContextStrategy,
 				Collections.<SecretBackendMetadata> emptyList(), taskScheduler);
 
 		assertThat(propertySourceLocator.getOrder()).isEqualTo(10);
@@ -80,6 +85,8 @@ public class LeasingVaultPropertySourceLocatorUnitTests {
 	public void shouldLocatePropertySources() {
 
 		when(configurableEnvironment.getActiveProfiles()).thenReturn(new String[0]);
+		when(vaultPropertySourceContextStrategy.buildContexts(configurableEnvironment))
+			.thenReturn(Collections.singletonList("/secret/appName"));
 
 		PropertySource<?> propertySource = propertySourceLocator
 				.locate(configurableEnvironment);


### PR DESCRIPTION
This PR extracts the Vault context/path building to a strategy pattern than can be provided/over-ridden via the Spring configuration.  The reason for providing this functionality is to allow applications that need/want to use a slightly different property source locator scheme to provide their own configuration of the context building logic.  This is extremely useful in cases where the vault backend structure is not determined by the development team (for instance, my environment uses the "environment" before the "application name" in the Vault path as the convention across the company). 