### PR TITLE
Create requested secret with mode setup in properties

### DIFF
--- a/spring-cloud-vault-config-aws/src/main/java/org/springframework/cloud/vault/config/aws/VaultAwsProperties.java
+++ b/spring-cloud-vault-config-aws/src/main/java/org/springframework/cloud/vault/config/aws/VaultAwsProperties.java
@@ -18,6 +18,7 @@ package org.springframework.cloud.vault.config.aws;
 import org.hibernate.validator.constraints.NotEmpty;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.cloud.vault.config.VaultSecretBackendDescriptor;
+import org.springframework.vault.core.lease.domain.RequestedSecret.Mode;
 
 import lombok.Data;
 
@@ -57,4 +58,9 @@ public class VaultAwsProperties implements VaultSecretBackendDescriptor {
 	 */
 	@NotEmpty
 	private String secretKeyProperty = "cloud.aws.credentials.secretKey";
+
+	/**
+	 * Lease mode
+	 */
+	private Mode leaseMode = Mode.RENEW;
 }

--- a/spring-cloud-vault-config-consul/src/main/java/org/springframework/cloud/vault/config/consul/VaultConsulProperties.java
+++ b/spring-cloud-vault-config-consul/src/main/java/org/springframework/cloud/vault/config/consul/VaultConsulProperties.java
@@ -18,6 +18,7 @@ package org.springframework.cloud.vault.config.consul;
 import org.hibernate.validator.constraints.NotEmpty;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.cloud.vault.config.VaultSecretBackendDescriptor;
+import org.springframework.vault.core.lease.domain.RequestedSecret.Mode;
 
 import lombok.Data;
 
@@ -51,4 +52,9 @@ public class VaultConsulProperties implements VaultSecretBackendDescriptor {
 	 */
 	@NotEmpty
 	private String tokenProperty = "spring.cloud.consul.token";
+
+	/**
+	 * Lease mode
+	 */
+	private Mode leaseMode = Mode.RENEW;
 }

--- a/spring-cloud-vault-config-databases/src/main/java/org/springframework/cloud/vault/config/databases/VaultCassandraProperties.java
+++ b/spring-cloud-vault-config-databases/src/main/java/org/springframework/cloud/vault/config/databases/VaultCassandraProperties.java
@@ -17,6 +17,7 @@ package org.springframework.cloud.vault.config.databases;
 
 import org.hibernate.validator.constraints.NotEmpty;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.vault.core.lease.domain.RequestedSecret.Mode;
 
 import lombok.Data;
 
@@ -56,4 +57,9 @@ public class VaultCassandraProperties implements DatabaseSecretProperties {
 	 */
 	@NotEmpty
 	private String passwordProperty = "spring.data.cassandra.password";
+
+	/**
+	 * Lease mode
+	 */
+	private Mode leaseMode = Mode.RENEW;
 }

--- a/spring-cloud-vault-config-databases/src/main/java/org/springframework/cloud/vault/config/databases/VaultConfigDatabaseBootstrapConfiguration.java
+++ b/spring-cloud-vault-config-databases/src/main/java/org/springframework/cloud/vault/config/databases/VaultConfigDatabaseBootstrapConfiguration.java
@@ -88,6 +88,7 @@ public class VaultConfigDatabaseBootstrapConfiguration {
 					Map<String, String> variables = new HashMap<>();
 					variables.put("backend", properties.getBackend());
 					variables.put("key", String.format("creds/%s", properties.getRole()));
+					variables.put("leaseMode", properties.getLeaseMode().name());
 					return variables;
 				}
 

--- a/spring-cloud-vault-config-databases/src/main/java/org/springframework/cloud/vault/config/databases/VaultMongoProperties.java
+++ b/spring-cloud-vault-config-databases/src/main/java/org/springframework/cloud/vault/config/databases/VaultMongoProperties.java
@@ -17,6 +17,7 @@ package org.springframework.cloud.vault.config.databases;
 
 import org.hibernate.validator.constraints.NotEmpty;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.vault.core.lease.domain.RequestedSecret.Mode;
 
 import lombok.Data;
 
@@ -56,4 +57,9 @@ public class VaultMongoProperties implements DatabaseSecretProperties {
 	 */
 	@NotEmpty
 	private String passwordProperty = "spring.data.mongodb.password";
+
+	/**
+	 * Lease mode
+	 */
+	private Mode leaseMode = Mode.RENEW;
 }

--- a/spring-cloud-vault-config-databases/src/main/java/org/springframework/cloud/vault/config/databases/VaultMySqlProperties.java
+++ b/spring-cloud-vault-config-databases/src/main/java/org/springframework/cloud/vault/config/databases/VaultMySqlProperties.java
@@ -3,6 +3,7 @@ package org.springframework.cloud.vault.config.databases;
 import org.hibernate.validator.constraints.NotEmpty;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.cloud.vault.config.VaultSecretBackendDescriptor;
+import org.springframework.vault.core.lease.domain.RequestedSecret.Mode;
 
 import lombok.Data;
 
@@ -43,4 +44,9 @@ public class VaultMySqlProperties
 	 */
 	@NotEmpty
 	private String passwordProperty = "spring.datasource.password";
+
+	/**
+	 * Lease mode
+	 */
+	private Mode leaseMode = Mode.RENEW;
 }

--- a/spring-cloud-vault-config-databases/src/main/java/org/springframework/cloud/vault/config/databases/VaultPostgreSqlProperties.java
+++ b/spring-cloud-vault-config-databases/src/main/java/org/springframework/cloud/vault/config/databases/VaultPostgreSqlProperties.java
@@ -17,6 +17,7 @@ package org.springframework.cloud.vault.config.databases;
 
 import org.hibernate.validator.constraints.NotEmpty;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.vault.core.lease.domain.RequestedSecret.Mode;
 
 import lombok.Data;
 
@@ -56,4 +57,9 @@ public class VaultPostgreSqlProperties implements DatabaseSecretProperties {
 	 */
 	@NotEmpty
 	private String passwordProperty = "spring.datasource.password";
+
+	/**
+	 * Lease mode
+	 */
+	private Mode leaseMode = Mode.RENEW;
 }

--- a/spring-cloud-vault-config-rabbitmq/src/main/java/org/springframework/cloud/vault/config/rabbitmq/VaultRabbitMqProperties.java
+++ b/spring-cloud-vault-config-rabbitmq/src/main/java/org/springframework/cloud/vault/config/rabbitmq/VaultRabbitMqProperties.java
@@ -18,6 +18,7 @@ package org.springframework.cloud.vault.config.rabbitmq;
 import org.hibernate.validator.constraints.NotEmpty;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.cloud.vault.config.VaultSecretBackendDescriptor;
+import org.springframework.vault.core.lease.domain.RequestedSecret.Mode;
 
 import lombok.Data;
 
@@ -57,4 +58,9 @@ public class VaultRabbitMqProperties implements VaultSecretBackendDescriptor {
 	 */
 	@NotEmpty
 	private String passwordProperty = "spring.rabbitmq.password";
+
+	/**
+	 * Lease mode
+	 */
+	private Mode leaseMode = Mode.RENEW;
 }

--- a/spring-cloud-vault-config/src/main/java/org/springframework/cloud/vault/config/LeasingVaultPropertySourceLocator.java
+++ b/spring-cloud-vault-config/src/main/java/org/springframework/cloud/vault/config/LeasingVaultPropertySourceLocator.java
@@ -28,6 +28,7 @@ import org.springframework.vault.VaultException;
 import org.springframework.vault.core.env.LeaseAwareVaultPropertySource;
 import org.springframework.vault.core.lease.SecretLeaseContainer;
 import org.springframework.vault.core.lease.domain.RequestedSecret;
+import org.springframework.vault.core.lease.domain.RequestedSecret.Mode;
 import org.springframework.vault.core.lease.event.LeaseErrorListener;
 import org.springframework.vault.core.lease.event.SecretLeaseEvent;
 import org.springframework.web.util.DefaultUriTemplateHandler;
@@ -88,7 +89,8 @@ class LeasingVaultPropertySourceLocator extends VaultPropertySourceLocatorSuppor
 
 		URI expand = TEMPLATE_HANDLER.expand("{backend}/{key}", accessor.getVariables());
 
-		final RequestedSecret secret = RequestedSecret.renewable(expand.getPath());
+		String leaseMode = accessor.getVariables().get("leaseMode");
+		final RequestedSecret secret = RequestedSecret.buildFromMode(leaseMode == null ? Mode.RENEW : Mode.valueOf(leaseMode), expand.getPath());
 
 		if (properties.isFailFast()) {
 			return createVaultPropertySourceFailFast(secret, accessor);

--- a/spring-cloud-vault-config/src/main/java/org/springframework/cloud/vault/config/VaultSecretBackendDescriptor.java
+++ b/spring-cloud-vault-config/src/main/java/org/springframework/cloud/vault/config/VaultSecretBackendDescriptor.java
@@ -16,6 +16,8 @@
 
 package org.springframework.cloud.vault.config;
 
+import org.springframework.vault.core.lease.domain.RequestedSecret.Mode;
+
 /**
  * Interface to be implemented by objects that describe a Vault secret backend.
  *
@@ -40,4 +42,9 @@ public interface VaultSecretBackendDescriptor {
 	 * @return {@literal true} if the backend is enabled.
 	 */
 	boolean isEnabled();
+
+	/**
+	 * Lease mode
+	 */
+	Mode getLeaseMode();
 }

--- a/spring-cloud-vault-dependencies/pom.xml
+++ b/spring-cloud-vault-dependencies/pom.xml
@@ -17,10 +17,6 @@
 	<name>Spring Cloud Vault Dependencies</name>
 	<description>Spring Cloud Vault Dependencies</description>
 
-	<properties>
-		<spring-vault.version>1.0.0.RC1</spring-vault.version>
-	</properties>
-
 	<dependencyManagement>
 		<dependencies>
 
@@ -28,7 +24,7 @@
 			<dependency>
 				<groupId>org.springframework.vault</groupId>
 				<artifactId>spring-vault-core</artifactId>
-				<version>${spring-vault.version}</version>
+				<version>${project.version}</version>
 				<!-- Provided by Spring Boot -->
 				<exclusions>
 					<exclusion>


### PR DESCRIPTION
This change aims to allow the application to request for rotating secrets. That way, the secret will be renewed until the max lease duration is reached. Then a new secret will be requested and used by the application.
