### PR TITLE
Allow vault standby nodes to pass health checks.

### DIFF
--- a/docs/src/main/asciidoc/quickstart.adoc
+++ b/docs/src/main/asciidoc/quickstart.adoc
@@ -194,6 +194,10 @@ status of the vault server will be available via the `/health` endpoint.
 The vault health indicator can be enabled or disabled through the
 property `health.vault.enabled` (default `true`).
 
+If Vault is configured in HA mode such that standby nodes are able to service
+requests directly, the vault health indicator can be configured to report a
+standby node as up through the property `health.vault.standby-ok` (default
+`false`).
 
 === Authentication
 


### PR DESCRIPTION
This change exposes a new configuration parameter: `health.vault.standby-ok` (default value is `false`). When set to `true`, the health check for Vault will treat standby nodes as `up`.

See https://www.vaultproject.io/api/system/health.html

Depends on spring-projects/spring-vault#100
Fixes gh-112.