### PR TITLE
Add support for Vault's database backend

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-vault.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-vault.adoc
@@ -579,6 +579,7 @@ mechanism to more easily roll keys.
 
 Spring Cloud Vault integrates with these backends:
 
+* <<vault.config.backends.database>>
 * <<vault.config.backends.cassandra>>
 * <<vault.config.backends.mongodb>>
 * <<vault.config.backends.mysql>>
@@ -589,8 +590,8 @@ backend in the configuration and the `spring-cloud-vault-config-databases`
 dependency.
 
 Vault ships since 0.7.1 with a dedicated `database` secret backend that allows
-database integration via plugins. You can use that specific backend by adapting
-one of the JDBC database properties above. Make sure to specify the appropriate
+database integration via plugins. You can use that specific backend by using the
+generic database backend. Make sure to specify the appropriate
 backend path, e.g. `spring.cloud.vault.mysql.role.backend=database`.
 
 .pom.xml
@@ -611,8 +612,47 @@ NOTE: Enabling multiple JDBC-compliant databases will generate credentials
 and store them by default in the same property keys hence property names for
 JDBC secrets need to be configured separately.
 
+[[vault.config.backends.database]]
+=== Database
+
+Spring Cloud Vault can obtain credentials for any Database listed at
+https://www.vaultproject.io/api/secret/databases/index.html.
+The integration can be enabled by setting
+`spring.cloud.vault.database.enabled=true` (default `false`) and
+providing the role name with `spring.cloud.vault.database.role=…`.
+
+Username and password are stored in `spring.datasource.username`
+and `spring.datasource.password` so using Spring Boot will
+pick up the generated credentials without further configuration.
+You can configure the property names by setting
+`spring.cloud.vault.database.username-property` and
+`spring.cloud.vault.database.password-property`.
+
+====
+[source,yaml]
+----
+spring.cloud.vault:
+    database:
+        enabled: true
+        role: readonly
+        backend: database
+        username-property: spring.datasource.username
+        password-property: spring.datasource.username
+----
+====
+
+* `enabled` setting this value to `true` enables the Database backend config usage
+* `role` sets the role name of the Database role definition
+* `backend` sets the path of the Database mount to use
+* `username-property` sets the property name in which the Database username is stored
+* `password-property` sets the property name in which the Database password is stored
+
+See also: https://www.vaultproject.io/docs/secrets/databases/index.html[Vault Documentation: Database Secrets backend]
+
+
 [[vault.config.backends.cassandra]]
 === Apache Cassandra
+This backend has been deprecated and might be removed from Vault soon.
 
 Spring Cloud Vault can obtain credentials for Apache Cassandra.
 The integration can be enabled by setting
@@ -650,6 +690,8 @@ See also: https://www.vaultproject.io/docs/secrets/cassandra/index.html[Vault Do
 [[vault.config.backends.mongodb]]
 === MongoDB
 
+This backend has been deprecated and might be removed from Vault soon.
+
 Spring Cloud Vault can obtain credentials for MongoDB.
 The integration can be enabled by setting
 `spring.cloud.vault.mongodb.enabled=true` (default `false`) and
@@ -686,6 +728,8 @@ See also: https://www.vaultproject.io/docs/secrets/mongodb/index.html[Vault Docu
 [[vault.config.backends.mysql]]
 === MySQL
 
+This backend has been deprecated and might be removed from Vault soon.
+
 Spring Cloud Vault can obtain credentials for MySQL.
 The integration can be enabled by setting
 `spring.cloud.vault.mysql.enabled=true` (default `false`) and
@@ -721,6 +765,8 @@ See also: https://www.vaultproject.io/docs/secrets/mysql/index.html[Vault Docume
 
 [[vault.config.backends.postgresql]]
 === PostgreSQL
+
+This backend has been deprecated and might be removed from Vault soon.
 
 Spring Cloud Vault can obtain credentials for PostgreSQL.
 The integration can be enabled by setting

--- a/docs/src/main/asciidoc/spring-cloud-vault.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-vault.adoc
@@ -652,7 +652,8 @@ See also: https://www.vaultproject.io/docs/secrets/databases/index.html[Vault Do
 
 [[vault.config.backends.cassandra]]
 === Apache Cassandra
-This backend has been deprecated and might be removed from Vault soon.
+This backend has been deprecated in Vault and it is recommended to use the `database` backend
+and mount it as `cassandra`.
 
 Spring Cloud Vault can obtain credentials for Apache Cassandra.
 The integration can be enabled by setting
@@ -690,7 +691,8 @@ See also: https://www.vaultproject.io/docs/secrets/cassandra/index.html[Vault Do
 [[vault.config.backends.mongodb]]
 === MongoDB
 
-This backend has been deprecated and might be removed from Vault soon.
+This backend has been deprecated in Vault and it is recommended to use the `database` backend
+and mount it as `mongodb`.
 
 Spring Cloud Vault can obtain credentials for MongoDB.
 The integration can be enabled by setting
@@ -727,8 +729,8 @@ See also: https://www.vaultproject.io/docs/secrets/mongodb/index.html[Vault Docu
 
 [[vault.config.backends.mysql]]
 === MySQL
-
-This backend has been deprecated and might be removed from Vault soon.
+This backend has been deprecated in Vault and it is recommended to use the `database` backend
+and mount it as `mysql`.
 
 Spring Cloud Vault can obtain credentials for MySQL.
 The integration can be enabled by setting
@@ -765,8 +767,8 @@ See also: https://www.vaultproject.io/docs/secrets/mysql/index.html[Vault Docume
 
 [[vault.config.backends.postgresql]]
 === PostgreSQL
-
-This backend has been deprecated and might be removed from Vault soon.
+This backend has been deprecated in Vault and it is recommended to use the `database` backend
+and mount it as `postgresql`.
 
 Spring Cloud Vault can obtain credentials for PostgreSQL.
 The integration can be enabled by setting

--- a/spring-cloud-vault-config-databases/src/main/java/org/springframework/cloud/vault/config/databases/VaultCassandraProperties.java
+++ b/spring-cloud-vault-config-databases/src/main/java/org/springframework/cloud/vault/config/databases/VaultCassandraProperties.java
@@ -15,12 +15,11 @@
  */
 package org.springframework.cloud.vault.config.databases;
 
-import javax.validation.constraints.NotEmpty;
-
 import lombok.Data;
-
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.validation.annotation.Validated;
+
+import javax.validation.constraints.NotEmpty;
 
 /**
  * Configuration properties for Vault using the Apache Cassandra integration.
@@ -30,7 +29,6 @@ import org.springframework.validation.annotation.Validated;
 @ConfigurationProperties("spring.cloud.vault.cassandra")
 @Data
 @Validated
-@Deprecated
 public class VaultCassandraProperties implements DatabaseSecretProperties {
 
 	/**

--- a/spring-cloud-vault-config-databases/src/main/java/org/springframework/cloud/vault/config/databases/VaultCassandraProperties.java
+++ b/spring-cloud-vault-config-databases/src/main/java/org/springframework/cloud/vault/config/databases/VaultCassandraProperties.java
@@ -30,6 +30,7 @@ import org.springframework.validation.annotation.Validated;
 @ConfigurationProperties("spring.cloud.vault.cassandra")
 @Data
 @Validated
+@Deprecated
 public class VaultCassandraProperties implements DatabaseSecretProperties {
 
 	/**

--- a/spring-cloud-vault-config-databases/src/main/java/org/springframework/cloud/vault/config/databases/VaultConfigDatabaseBootstrapConfiguration.java
+++ b/spring-cloud-vault-config-databases/src/main/java/org/springframework/cloud/vault/config/databases/VaultConfigDatabaseBootstrapConfiguration.java
@@ -38,7 +38,7 @@ import org.springframework.vault.core.util.PropertyTransformer;
 @Configuration
 @EnableConfigurationProperties({ VaultMySqlProperties.class,
 		VaultPostgreSqlProperties.class, VaultCassandraProperties.class,
-		VaultMongoProperties.class })
+		VaultMongoProperties.class, VaultDatabaseProperties.class })
 public class VaultConfigDatabaseBootstrapConfiguration {
 
 	@Bean

--- a/spring-cloud-vault-config-databases/src/main/java/org/springframework/cloud/vault/config/databases/VaultDatabaseProperties.java
+++ b/spring-cloud-vault-config-databases/src/main/java/org/springframework/cloud/vault/config/databases/VaultDatabaseProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 the original author or authors.
+ * Copyright 2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,49 +15,46 @@
  */
 package org.springframework.cloud.vault.config.databases;
 
-import javax.validation.constraints.NotEmpty;
-
 import lombok.Data;
-
+import org.hibernate.validator.constraints.NotEmpty;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.validation.annotation.Validated;
 
 /**
- * Configuration properties for Vault using the PostgreSQL integration.
+ * Configuration properties for Vault using the Database integration.
  *
  * @author Mark Paluch
  */
-@ConfigurationProperties("spring.cloud.vault.postgresql")
+@ConfigurationProperties("spring.cloud.vault.database")
 @Data
 @Validated
-@Deprecated
-public class VaultPostgreSqlProperties implements DatabaseSecretProperties {
+public class VaultDatabaseProperties implements DatabaseSecretProperties {
 
-	/**
-	 * Enable postgresql backend usage.
-	 */
-	private boolean enabled = false;
+    /**
+     * Enable cassandra backend usage.
+     */
+    private boolean enabled = false;
 
-	/**
-	 * Role name for credentials.
-	 */
-	private String role;
+    /**
+     * Role name for credentials.
+     */
+    private String role;
 
-	/**
-	 * postgresql backend path.
-	 */
-	@NotEmpty
-	private String backend = "postgresql";
+    /**
+     * Cassandra backend path.
+     */
+    @NotEmpty
+    private String backend = "database";
 
-	/**
-	 * Target property for the obtained username.
-	 */
-	@NotEmpty
-	private String usernameProperty = "spring.datasource.username";
+    /**
+     * Target property for the obtained username.
+     */
+    @NotEmpty
+    private String usernameProperty;
 
-	/**
-	 * Target property for the obtained username.
-	 */
-	@NotEmpty
-	private String passwordProperty = "spring.datasource.password";
+    /**
+     * Target property for the obtained password.
+     */
+    @NotEmpty
+    private String passwordProperty;
 }

--- a/spring-cloud-vault-config-databases/src/main/java/org/springframework/cloud/vault/config/databases/VaultDatabaseProperties.java
+++ b/spring-cloud-vault-config-databases/src/main/java/org/springframework/cloud/vault/config/databases/VaultDatabaseProperties.java
@@ -50,11 +50,11 @@ public class VaultDatabaseProperties implements DatabaseSecretProperties {
      * Target property for the obtained username.
      */
     @NotEmpty
-    private String usernameProperty;
+    private String usernameProperty = "spring.datasource.username";
 
     /**
      * Target property for the obtained password.
      */
     @NotEmpty
-    private String passwordProperty;
+    private String passwordProperty = "spring.datasource.password";
 }

--- a/spring-cloud-vault-config-databases/src/main/java/org/springframework/cloud/vault/config/databases/VaultDatabaseProperties.java
+++ b/spring-cloud-vault-config-databases/src/main/java/org/springframework/cloud/vault/config/databases/VaultDatabaseProperties.java
@@ -42,7 +42,7 @@ public class VaultDatabaseProperties implements DatabaseSecretProperties {
     private String role;
 
     /**
-     * Cassandra backend path.
+     * Database backend path.
      */
     @NotEmpty
     private String backend = "database";

--- a/spring-cloud-vault-config-databases/src/main/java/org/springframework/cloud/vault/config/databases/VaultDatabaseProperties.java
+++ b/spring-cloud-vault-config-databases/src/main/java/org/springframework/cloud/vault/config/databases/VaultDatabaseProperties.java
@@ -16,14 +16,15 @@
 package org.springframework.cloud.vault.config.databases;
 
 import lombok.Data;
-import org.hibernate.validator.constraints.NotEmpty;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.validation.annotation.Validated;
+
+import javax.validation.constraints.NotEmpty;
 
 /**
  * Configuration properties for Vault using the Database integration.
  *
- * @author Mark Paluch
+ * @author Per Abich
  */
 @ConfigurationProperties("spring.cloud.vault.database")
 @Data
@@ -31,7 +32,7 @@ import org.springframework.validation.annotation.Validated;
 public class VaultDatabaseProperties implements DatabaseSecretProperties {
 
     /**
-     * Enable cassandra backend usage.
+     * Enable database backend usage.
      */
     private boolean enabled = false;
 

--- a/spring-cloud-vault-config-databases/src/main/java/org/springframework/cloud/vault/config/databases/VaultMongoProperties.java
+++ b/spring-cloud-vault-config-databases/src/main/java/org/springframework/cloud/vault/config/databases/VaultMongoProperties.java
@@ -30,6 +30,7 @@ import org.springframework.validation.annotation.Validated;
 @ConfigurationProperties("spring.cloud.vault.mongodb")
 @Data
 @Validated
+@Deprecated
 public class VaultMongoProperties implements DatabaseSecretProperties {
 
 	/**

--- a/spring-cloud-vault-config-databases/src/main/java/org/springframework/cloud/vault/config/databases/VaultMongoProperties.java
+++ b/spring-cloud-vault-config-databases/src/main/java/org/springframework/cloud/vault/config/databases/VaultMongoProperties.java
@@ -15,12 +15,11 @@
  */
 package org.springframework.cloud.vault.config.databases;
 
-import javax.validation.constraints.NotEmpty;
-
 import lombok.Data;
-
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.validation.annotation.Validated;
+
+import javax.validation.constraints.NotEmpty;
 
 /**
  * Configuration properties for Vault using the MongoDB integration.
@@ -30,7 +29,6 @@ import org.springframework.validation.annotation.Validated;
 @ConfigurationProperties("spring.cloud.vault.mongodb")
 @Data
 @Validated
-@Deprecated
 public class VaultMongoProperties implements DatabaseSecretProperties {
 
 	/**

--- a/spring-cloud-vault-config-databases/src/main/java/org/springframework/cloud/vault/config/databases/VaultPostgreSqlProperties.java
+++ b/spring-cloud-vault-config-databases/src/main/java/org/springframework/cloud/vault/config/databases/VaultPostgreSqlProperties.java
@@ -15,12 +15,11 @@
  */
 package org.springframework.cloud.vault.config.databases;
 
-import javax.validation.constraints.NotEmpty;
-
 import lombok.Data;
-
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.validation.annotation.Validated;
+
+import javax.validation.constraints.NotEmpty;
 
 /**
  * Configuration properties for Vault using the PostgreSQL integration.
@@ -30,7 +29,6 @@ import org.springframework.validation.annotation.Validated;
 @ConfigurationProperties("spring.cloud.vault.postgresql")
 @Data
 @Validated
-@Deprecated
 public class VaultPostgreSqlProperties implements DatabaseSecretProperties {
 
 	/**

--- a/spring-cloud-vault-config-databases/src/test/java/org/springframework/cloud/vault/config/databases/VaultConfigDatabaseBootstrapConfigurationTests.java
+++ b/spring-cloud-vault-config-databases/src/test/java/org/springframework/cloud/vault/config/databases/VaultConfigDatabaseBootstrapConfigurationTests.java
@@ -17,7 +17,6 @@ package org.springframework.cloud.vault.config.databases;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -35,7 +34,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * Tests for {@link VaultConfigDatabaseBootstrapConfiguration}.
  *
- * @author Mark Paluch
+ * @author Per Abich
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @SpringBootTest(classes = CustomBootstrapConfiguration.class, properties = {

--- a/spring-cloud-vault-config-databases/src/test/java/org/springframework/cloud/vault/config/databases/VaultConfigDatabaseTests.java
+++ b/spring-cloud-vault-config-databases/src/test/java/org/springframework/cloud/vault/config/databases/VaultConfigDatabaseTests.java
@@ -88,15 +88,15 @@ public class VaultConfigDatabaseTests {
         VaultOperations vaultOperations = vaultRule.prepare().getVaultOperations();
 
         Map<String, String> connection = new HashMap<>();
-        connection.put("plugin_name", "cassandra-database-plugin");
+        connection.put("plugin_name", "postgresql-database-plugin");
         connection.put("allowed_roles", ROLE_NAME);
         connection.put("connection_url", CONNECTION_URL);
-        vaultOperations.write(String.format("%s/config/connection", BACKEND), connection);
+        vaultOperations.write(String.format("%s/config/postgresql", BACKEND), connection);
 
         Map<String, String> role = new HashMap<>();
 
         role.put("creation_statements", CREATE_USER_AND_GRANT_SQL);
-        role.put("db_name", "cassandra");
+        role.put("db_name", "postgresql");
 
         vaultOperations.write(String.format("%s/roles/%s", BACKEND, "readonly"), role);
 

--- a/spring-cloud-vault-config-databases/src/test/java/org/springframework/cloud/vault/config/databases/VaultConfigDatabaseTests.java
+++ b/spring-cloud-vault-config-databases/src/test/java/org/springframework/cloud/vault/config/databases/VaultConfigDatabaseTests.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.vault.config.databases;
+
+import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.PlainTextAuthProvider;
+import com.datastax.driver.core.Session;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.vault.util.CanConnect;
+import org.springframework.cloud.vault.util.VaultRule;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.vault.core.VaultOperations;
+
+import java.net.InetSocketAddress;
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assume.assumeTrue;
+
+/**
+ * Integration tests using the cassandra secret backend. In case this test should fail
+ * because of SSL make sure you run the test within the
+ * spring-cloud-vault-config/spring-cloud-vault-config directory as the keystore is
+ * referenced with {@code ../work/keystore.jks}.
+ * 
+ * @author Mark Paluch
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringBootTest(classes = VaultConfigDatabaseTests.TestApplication.class, properties = {
+		"spring.cloud.vault.database.enabled=true",
+		"spring.cloud.vault.database.role=readonly" })
+public class VaultConfigDatabaseTests {
+
+	private final static String CASSANDRA_HOST = "localhost";
+	private final static int CASSANDRA_PORT = 9042;
+
+	private final static String CASSANDRA_USERNAME = "springvault";
+	private final static String CASSANDRA_PASSWORD = "springvault";
+
+	private final static String CREATE_USER_AND_GRANT_CQL = "CREATE USER '{{username}}' WITH PASSWORD '{{password}}' NOSUPERUSER;"
+			+ "GRANT SELECT ON ALL KEYSPACES TO {{username}};";
+	private static final String ROLE_NAME = "readonly";
+	private static final String BACKEND = "database";
+
+	/**
+	 * Initialize the database secret backend with the cassandra plugin.
+	 *
+	 * @throws Exception
+	 */
+	@BeforeClass
+	public static void beforeClass() throws Exception {
+
+		assumeTrue(CanConnect.to(new InetSocketAddress(CASSANDRA_HOST, CASSANDRA_PORT)));
+
+		VaultRule vaultRule = new VaultRule();
+		vaultRule.before();
+
+		if (!vaultRule.prepare().hasSecretBackend(BACKEND)) {
+			vaultRule.prepare().mountSecret(BACKEND);
+		}
+
+		VaultOperations vaultOperations = vaultRule.prepare().getVaultOperations();
+
+		Map<String, String> connection = new HashMap<>();
+		connection.put("plugin_name", "cassandra-database-plugin");
+		connection.put("allowed_roles", ROLE_NAME);
+		connection.put("hosts", CASSANDRA_HOST);
+		connection.put("username", CASSANDRA_USERNAME);
+		connection.put("password", CASSANDRA_PASSWORD);
+
+		vaultOperations.write(String.format("%s/config/cassandra", BACKEND),
+				connection);
+
+		Map<String, String> role = new HashMap<>();
+
+		role.put("creation_statements", CREATE_USER_AND_GRANT_CQL);
+
+		vaultOperations.write(String.format("%s/roles/%s",BACKEND,ROLE_NAME), role);
+	}
+
+	@Value("${spring.data.cassandra.username}")
+	String username;
+
+	@Value("${spring.data.cassandra.password}")
+	String password;
+
+	@Autowired
+	Cluster cluster;
+
+	@Test
+	public void shouldConnectUsingCluster() throws SQLException {
+		cluster.connect().close();
+	}
+
+	@Test
+	public void shouldUseAuthenticationSet() throws SQLException {
+		assertThat(cluster.getConfiguration().getProtocolOptions().getAuthProvider())
+				.isInstanceOf(PlainTextAuthProvider.class);
+	}
+
+	@Test
+	public void shouldConnectUsingCassandraClient() throws SQLException {
+
+		Cluster cluster = Cluster.builder().addContactPoint(CASSANDRA_HOST)
+				.withAuthProvider(new PlainTextAuthProvider(username, password)).build();
+		Session session = cluster.connect();
+		session.close();
+		cluster.close();
+	}
+
+	@SpringBootApplication
+	public static class TestApplication {
+
+		public static void main(String[] args) {
+			SpringApplication.run(TestApplication.class, args);
+		}
+	}
+}

--- a/spring-cloud-vault-config-databases/src/test/java/org/springframework/cloud/vault/config/databases/VaultConfigDatabaseTests.java
+++ b/spring-cloud-vault-config-databases/src/test/java/org/springframework/cloud/vault/config/databases/VaultConfigDatabaseTests.java
@@ -50,7 +50,10 @@ import static org.junit.Assume.assumeTrue;
 @RunWith(SpringJUnit4ClassRunner.class)
 @SpringBootTest(classes = VaultConfigDatabaseTests.TestApplication.class, properties = {
 		"spring.cloud.vault.database.enabled=true",
-		"spring.cloud.vault.database.role=readonly" })
+		"spring.cloud.vault.database.role=readonly",
+        "spring.cloud.vault.database.username-property=spring.data.cassandra.username",
+        "spring.cloud.vault.database.password-property=spring.data.cassandra.password",
+})
 public class VaultConfigDatabaseTests {
 
 	private final static String CASSANDRA_HOST = "localhost";

--- a/spring-cloud-vault-config-databases/src/test/java/org/springframework/cloud/vault/config/databases/VaultConfigDatabaseTests.java
+++ b/spring-cloud-vault-config-databases/src/test/java/org/springframework/cloud/vault/config/databases/VaultConfigDatabaseTests.java
@@ -25,6 +25,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.vault.util.CanConnect;
 import org.springframework.cloud.vault.util.VaultRule;
+import org.springframework.cloud.vault.util.Version;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.vault.core.VaultOperations;
 
@@ -80,6 +81,9 @@ public class VaultConfigDatabaseTests {
 
         VaultRule vaultRule = new VaultRule();
         vaultRule.before();
+
+        assumeTrue(vaultRule.prepare().getVersion()
+                .isGreaterThanOrEqualTo(Version.parse("0.7.1")));
 
         if (!vaultRule.prepare().hasSecretBackend(BACKEND)) {
             vaultRule.prepare().mountSecret(BACKEND);

--- a/spring-cloud-vault-config-databases/src/test/java/org/springframework/cloud/vault/config/databases/VaultConfigDatabaseTests.java
+++ b/spring-cloud-vault-config-databases/src/test/java/org/springframework/cloud/vault/config/databases/VaultConfigDatabaseTests.java
@@ -96,6 +96,7 @@ public class VaultConfigDatabaseTests {
 		Map<String, String> role = new HashMap<>();
 
 		role.put("creation_statements", CREATE_USER_AND_GRANT_CQL);
+		role.put("db_name", "cassandra");
 
 		vaultOperations.write(String.format("%s/roles/%s",BACKEND,ROLE_NAME), role);
 	}

--- a/spring-cloud-vault-config-databases/src/test/java/org/springframework/cloud/vault/config/databases/VaultConfigDatabaseTests.java
+++ b/spring-cloud-vault-config-databases/src/test/java/org/springframework/cloud/vault/config/databases/VaultConfigDatabaseTests.java
@@ -132,7 +132,7 @@ public class VaultConfigDatabaseTests {
     public static class TestApplication {
 
         public static void main(String[] args) {
-            SpringApplication.run(TestApplication.class, args);
+            SpringApplication.run(TestApplication.class, args).registerShutdownHook();
         }
     }
 }


### PR DESCRIPTION
Since the old style database backends have been deprecated in Vault, we need to move to the new database backend (which will lead to a reduction in code).