### PR TITLE
URL Cleanup

### DIFF
--- a/CODE_OF_CONDUCT.adoc
+++ b/CODE_OF_CONDUCT.adoc
@@ -24,4 +24,4 @@ Instances of abusive, harassing, or otherwise unacceptable behavior may be repor
 All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances.
 Maintainers are obligated to maintain confidentiality with regard to the reporter of an incident.
 
-This Code of Conduct is adapted from the http://contributor-covenant.org[Contributor Covenant], version 1.3.0, available at http://contributor-covenant.org/version/1/3/0/[contributor-covenant.org/version/1/3/0/].
+This Code of Conduct is adapted from the https://contributor-covenant.org[Contributor Covenant], version 1.3.0, available at https://contributor-covenant.org/version/1/3/0/[contributor-covenant.org/version/1/3/0/].

--- a/README.adoc
+++ b/README.adoc
@@ -4,7 +4,7 @@ Manual changes to this file will be lost when it is generated again.
 Edit the files in the src/main/asciidoc/ directory instead.
 ////
 
-:docs: http://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html
+:docs: https://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html
 
 
 Spring Cloud Vault Config provides client-side support for externalized configuration in a distributed system. With https://www.vaultproject.io[HashiCorp's Vault] you have a central place to manage external secret properties for applications across all environments. Vault can manage static and dynamic secrets such as username/password for remote applications/resources and provide credentials for external services such as MySQL, PostgreSQL, Apache Cassandra, MongoDB, Consul, AWS and more.
@@ -38,7 +38,7 @@ Specifically for Spring applications:
 
 == Quick Start
 
-:docs: http://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html
+:docs: https://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html
 
 *Prerequisites*
 
@@ -331,7 +331,7 @@ credentials and you already have those.
 
 The projects that require middleware generally include a
 `docker-compose.yml`, so consider using
-http://compose.docker.io/[Docker Compose] to run the middeware servers
+https://compose.docker.io/[Docker Compose] to run the middeware servers
 in Docker containers. See the README in the
 https://github.com/spring-cloud-samples/scripts[scripts demo
 repository] for specific instructions about the common cases of mongo,
@@ -353,13 +353,13 @@ a modified file in the correct place. Just commit it and push the change.
 
 === Working with the code
 If you don't have an IDE preference we would recommend that you use
-http://www.springsource.com/developer/sts[Spring Tools Suite] or
-http://eclipse.org[Eclipse] when working with the code. We use the
-http://eclipse.org/m2e/[m2eclipse] eclipse plugin for maven support. Other IDEs and tools
+https://www.springsource.com/developer/sts[Spring Tools Suite] or
+https://eclipse.org[Eclipse] when working with the code. We use the
+https://eclipse.org/m2e/[m2eclipse] eclipse plugin for maven support. Other IDEs and tools
 should also work without issue as long as they use Maven 3.3.3 or better.
 
 ==== Importing into eclipse with m2eclipse
-We recommend the http://eclipse.org/m2e/[m2eclipse] eclipse plugin when working with
+We recommend the https://eclipse.org/m2e/[m2eclipse] eclipse plugin when working with
 eclipse. If you don't already have m2eclipse installed it is available from the "eclipse
 marketplace".
 
@@ -417,7 +417,7 @@ added after the original pull request but before a merge.
   `eclipse-code-formatter.xml` file from the
   https://raw.githubusercontent.com/spring-cloud/spring-cloud-build/master/spring-cloud-dependencies-parent/eclipse-code-formatter.xml[Spring
   Cloud Build] project. If using IntelliJ, you can use the
-  http://plugins.jetbrains.com/plugin/6546[Eclipse Code Formatter
+  https://plugins.jetbrains.com/plugin/6546[Eclipse Code Formatter
   Plugin] to import the same file.
 * Make sure all new `.java` files to have a simple Javadoc class comment with at least an
   `@author` tag identifying you, and preferably at least a paragraph on what the class is
@@ -430,7 +430,7 @@ added after the original pull request but before a merge.
 * A few unit tests would help a lot as well -- someone has to do it.
 * If no-one else is using your branch, please rebase it against the current master (or
   other target branch in the main project).
-* When writing a commit message please follow http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html[these conventions],
+* When writing a commit message please follow https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html[these conventions],
   if you are fixing an existing issue please add `Fixes gh-XXXX` at the end of the commit
   message (where XXXX is the issue number).
 
@@ -501,7 +501,7 @@ If you need to suppress some rules (e.g. line length needs to be longer), then i
 <?xml version="1.0"?>
 <!DOCTYPE suppressions PUBLIC
 		"-//Puppy Crawl//DTD Suppressions 1.1//EN"
-		"http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
+		"https://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
 <suppressions>
 	<suppress files=".*ConfigServerApplication\.java" checks="HideUtilityClassConstructor"/>
 	<suppress files=".*ConfigClientWatch\.java" checks="LineLengthCheck"/>

--- a/docs/src/main/asciidoc/README.adoc
+++ b/docs/src/main/asciidoc/README.adoc
@@ -1,4 +1,4 @@
-:docs: http://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html
+:docs: https://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html
 
 include::intro.adoc[]
 

--- a/docs/src/main/asciidoc/quickstart.adoc
+++ b/docs/src/main/asciidoc/quickstart.adoc
@@ -1,4 +1,4 @@
-:docs: http://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html
+:docs: https://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html
 
 *Prerequisites*
 

--- a/spring-cloud-vault-config-databases/src/test/resources/cassandra.yaml
+++ b/spring-cloud-vault-config-databases/src/test/resources/cassandra.yaml
@@ -1,7 +1,7 @@
 # Cassandra storage config YAML
 
 # NOTE:
-#   See http://wiki.apache.org/cassandra/StorageConfiguration for
+#   See https://wiki.apache.org/cassandra/StorageConfiguration for
 #   full explanations of configuration directives
 # /NOTE
 
@@ -21,7 +21,7 @@ cluster_name: 'Test Cluster'
 # on subsequent starts, this setting will apply even if initial token is set.
 #
 # If you already have a cluster with 1 token per node, and wish to migrate to
-# multiple tokens per node, see http://wiki.apache.org/cassandra/Operations
+# multiple tokens per node, see https://wiki.apache.org/cassandra/Operations
 num_tokens: 256
 
 # Triggers automatic allocation of num_tokens tokens for this node. The allocation
@@ -41,7 +41,7 @@ num_tokens: 256
 # that do not have vnodes enabled.
 # initial_token:
 
-# See http://wiki.apache.org/cassandra/HintedHandoff
+# See https://wiki.apache.org/cassandra/HintedHandoff
 # May either be "true" or "false" to enable globally
 hinted_handoff_enabled: true
 
@@ -1028,7 +1028,7 @@ request_scheduler: org.apache.cassandra.scheduler.NoScheduler
 #
 # The passwords used in these options must match the passwords used when generating
 # the keystore and truststore.  For instructions on generating these files, see:
-# http://download.oracle.com/javase/6/docs/technotes/guides/security/jsse/JSSERefGuide.html#CreateKeystore
+# https://download.oracle.com/javase/6/docs/technotes/guides/security/jsse/JSSERefGuide.html#CreateKeystore
 #
 server_encryption_options:
     internode_encryption: none
@@ -1121,7 +1121,7 @@ windows_timer_interval: 1
 #
 # It is strongly recommended to download and install Java Cryptography Extension (JCE)
 # Unlimited Strength Jurisdiction Policy Files for your version of the JDK.
-# (current link: http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html)
+# (current link: https://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html)
 #
 # Currently, only the following file types are supported for transparent data encryption, although
 # more are coming in future cassandra releases: commitlog, hints
@@ -1150,7 +1150,7 @@ transparent_data_encryption_options:
 # will use them to make sure other replicas also know about the deleted rows.
 # With workloads that generate a lot of tombstones, this can cause performance
 # problems and even exaust the server heap.
-# (http://www.datastax.com/dev/blog/cassandra-anti-patterns-queues-and-queue-like-datasets)
+# (https://www.datastax.com/dev/blog/cassandra-anti-patterns-queues-and-queue-like-datasets)
 # Adjust the thresholds here if you understand the dangers and want to
 # scan more tombstones anyway.  These thresholds may also be adjusted at runtime
 # using the StorageService mbean.

--- a/spring-cloud-vault-config-rabbitmq/src/test/java/org/springframework/cloud/vault/config/rabbitmq/RabbitMqSecretIntegrationTests.java
+++ b/spring-cloud-vault-config-rabbitmq/src/test/java/org/springframework/cloud/vault/config/rabbitmq/RabbitMqSecretIntegrationTests.java
@@ -52,7 +52,7 @@ public class RabbitMqSecretIntegrationTests extends IntegrationTestSupport {
 
 	private static final String RABBITMQ_PASSWORD = "guest";
 
-	private static final String RABBITMQ_URI = String.format("http://%s:%d",
+	private static final String RABBITMQ_URI = String.format("https://%s:%d",
 			RABBITMQ_HOST, RABBITMQ_HTTP_MANAGEMENT_PORT);
 
 	private static final String VHOSTS_ROLE = "{\"/\":{\"write\": \".*\", \"read\": \".*\"}}";

--- a/spring-cloud-vault-config-rabbitmq/src/test/java/org/springframework/cloud/vault/config/rabbitmq/VaultConfigRabbitMqTests.java
+++ b/spring-cloud-vault-config-rabbitmq/src/test/java/org/springframework/cloud/vault/config/rabbitmq/VaultConfigRabbitMqTests.java
@@ -65,7 +65,7 @@ public class VaultConfigRabbitMqTests {
 
 	private static final String RABBITMQ_PASSWORD = "guest";
 
-	private static final String RABBITMQ_URI = String.format("http://%s:%d",
+	private static final String RABBITMQ_URI = String.format("https://%s:%d",
 			RABBITMQ_HOST, RABBITMQ_HTTP_MANAGEMENT_PORT);
 
 	private static final String VHOSTS_ROLE = "{\"/\":{\"write\": \".*\", \"read\": \".*\"}}";

--- a/spring-cloud-vault-config/src/main/java/org/springframework/cloud/vault/config/VaultProperties.java
+++ b/spring-cloud-vault-config/src/main/java/org/springframework/cloud/vault/config/VaultProperties.java
@@ -244,7 +244,7 @@ public class VaultProperties implements EnvironmentAware {
 		 * URL of the AWS-EC2 PKCS7 identity document.
 		 */
 		@NotEmpty
-		private String identityDocument = "http://169.254.169.254/latest/dynamic/instance-identity/pkcs7";
+		private String identityDocument = "https://169.254.169.254/latest/dynamic/instance-identity/pkcs7";
 
 		/**
 		 * Mount path of the AWS-EC2 authentication backend.

--- a/src/main/resources/license.txt
+++ b/src/main/resources/license.txt
@@ -207,7 +207,7 @@ similar licenses that require the source code and/or modifications to
 source code to be made available (as would be noted above), you may obtain a 
 copy of the source code corresponding to the binaries for such open source 
 components and modifications thereto, if any, (the "Source Files"), by 
-downloading the Source Files from http://www.springsource.org/download, 
+downloading the Source Files from https://www.springsource.org/download, 
 or by sending a request, with your name and address to: VMware, Inc., 3401 Hillview 
 Avenue, Palo Alto, CA 94304, United States of America or email info@vmware.com.  All 
 such requests should clearly specify:  OPEN SOURCE FILES REQUEST, Attention General 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://169.254.169.254/latest/dynamic/instance-identity/pkcs7 (AnnotatedConnectException) with 1 occurrences migrated to:  
  https://169.254.169.254/latest/dynamic/instance-identity/pkcs7 ([https](https://169.254.169.254/latest/dynamic/instance-identity/pkcs7) result ConnectTimeoutException).
* [ ] http://%s:%d (UnknownHostException) with 2 occurrences migrated to:  
  https://%s:%d ([https](https://%s:%d) result UnknownHostException).
* [ ] http://compose.docker.io/ (UnknownHostException) with 1 occurrences migrated to:  
  https://compose.docker.io/ ([https](https://compose.docker.io/) result UnknownHostException).
* [ ] http://www.puppycrawl.com/dtds/suppressions_1_1.dtd (404) with 1 occurrences migrated to:  
  https://www.puppycrawl.com/dtds/suppressions_1_1.dtd ([https](https://www.puppycrawl.com/dtds/suppressions_1_1.dtd) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html with 4 occurrences migrated to:  
  https://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html ([https](https://cloud.spring.io/spring-cloud-vault/spring-cloud-vault.html) result 200).
* [ ] http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html with 1 occurrences migrated to:  
  https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html ([https](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html) result 200).
* [ ] http://wiki.apache.org/cassandra/HintedHandoff with 1 occurrences migrated to:  
  https://wiki.apache.org/cassandra/HintedHandoff ([https](https://wiki.apache.org/cassandra/HintedHandoff) result 200).
* [ ] http://wiki.apache.org/cassandra/Operations with 1 occurrences migrated to:  
  https://wiki.apache.org/cassandra/Operations ([https](https://wiki.apache.org/cassandra/Operations) result 200).
* [ ] http://wiki.apache.org/cassandra/StorageConfiguration with 1 occurrences migrated to:  
  https://wiki.apache.org/cassandra/StorageConfiguration ([https](https://wiki.apache.org/cassandra/StorageConfiguration) result 200).
* [ ] http://www.datastax.com/dev/blog/cassandra-anti-patterns-queues-and-queue-like-datasets with 1 occurrences migrated to:  
  https://www.datastax.com/dev/blog/cassandra-anti-patterns-queues-and-queue-like-datasets ([https](https://www.datastax.com/dev/blog/cassandra-anti-patterns-queues-and-queue-like-datasets) result 200).
* [ ] http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html with 1 occurrences migrated to:  
  https://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html ([https](https://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html) result 200).
* [ ] http://contributor-covenant.org with 1 occurrences migrated to:  
  https://contributor-covenant.org ([https](https://contributor-covenant.org) result 301).
* [ ] http://contributor-covenant.org/version/1/3/0/ with 1 occurrences migrated to:  
  https://contributor-covenant.org/version/1/3/0/ ([https](https://contributor-covenant.org/version/1/3/0/) result 301).
* [ ] http://plugins.jetbrains.com/plugin/6546 with 1 occurrences migrated to:  
  https://plugins.jetbrains.com/plugin/6546 ([https](https://plugins.jetbrains.com/plugin/6546) result 301).
* [ ] http://download.oracle.com/javase/6/docs/technotes/guides/security/jsse/JSSERefGuide.html with 1 occurrences migrated to:  
  https://download.oracle.com/javase/6/docs/technotes/guides/security/jsse/JSSERefGuide.html ([https](https://download.oracle.com/javase/6/docs/technotes/guides/security/jsse/JSSERefGuide.html) result 302).
* [ ] http://eclipse.org with 1 occurrences migrated to:  
  https://eclipse.org ([https](https://eclipse.org) result 302).
* [ ] http://eclipse.org/m2e/ with 2 occurrences migrated to:  
  https://eclipse.org/m2e/ ([https](https://eclipse.org/m2e/) result 302).
* [ ] http://www.springsource.com/developer/sts with 1 occurrences migrated to:  
  https://www.springsource.com/developer/sts ([https](https://www.springsource.com/developer/sts) result 302).
* [ ] http://www.springsource.org/download with 1 occurrences migrated to:  
  https://www.springsource.org/download ([https](https://www.springsource.org/download) result 302).