### PR TITLE
URL Cleanup

### DIFF
--- a/spring-cloud-vault-config/src/main/java/org/springframework/cloud/vault/config/VaultProperties.java
+++ b/spring-cloud-vault-config/src/main/java/org/springframework/cloud/vault/config/VaultProperties.java
@@ -243,7 +243,7 @@ public class VaultProperties implements EnvironmentAware {
 		 * URL of the AWS-EC2 PKCS7 identity document.
 		 */
 		@NotEmpty
-		private String identityDocument = "http://169.254.169.254/latest/dynamic/instance-identity/pkcs7";
+		private String identityDocument = "https://169.254.169.254/latest/dynamic/instance-identity/pkcs7";
 
 		/**
 		 * Mount path of the AWS-EC2 authentication backend.


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://169.254.169.254/latest/dynamic/instance-identity/pkcs7 (AnnotatedConnectException) with 1 occurrences migrated to:  
  https://169.254.169.254/latest/dynamic/instance-identity/pkcs7 ([https](https://169.254.169.254/latest/dynamic/instance-identity/pkcs7) result ConnectTimeoutException).

# Ignored
These URLs were intentionally ignored.

* http://%s:%d with 2 occurrences