### PR TITLE
Update README for encrypt/decrypt

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -32,7 +32,7 @@ Specifically for Spring applications:
 {docs}#vault.config.authentication.awsec2[AWS-EC2] authentication,
 {docs}#vault.config.authentication.awsiam[AWS-IAM] authentication, and
 {docs}#vault.config.authentication.kubernetes[Kubernetes] authentication.
-
+* Transmit data to Vault for encryption and decryption.
 * Bootstrap application context: a parent context for the main application that can be trained to do anything.
 
 


### PR DESCRIPTION
Readme file was missing the transit encrypt/decrypt feature that many enterprise users will be interested in.
This feature is available in the VaultOperations interface: https://docs.spring.io/spring-vault/docs/current/api/org/springframework/vault/core/VaultOperations.html#opsForTransit-- and has a pretty well documented example here: https://learn.hashicorp.com/vault/encryption-as-a-service/eaas-spring-demo