### PR TITLE
Fixed outdated vault commands

### DIFF
--- a/docs/src/main/asciidoc/quickstart.adoc
+++ b/docs/src/main/asciidoc/quickstart.adoc
@@ -72,7 +72,7 @@ If you want to use Vault for your application or give it a try then you need to 
 ----
 $ export VAULT_ADDR="https://localhost:8200"
 $ export VAULT_SKIP_VERIFY=true # Don't do this for production
-$ vault init
+$ vault operator init
 ----
 
 You should see something like:
@@ -102,12 +102,12 @@ environment variable.
 
 [source,bash]
 ----
-$ vault unseal (Key 1)
-$ vault unseal (Key 2)
-$ vault unseal (Key 3)
+$ vault operator unseal (Key 1)
+$ vault operator unseal (Key 2)
+$ vault operator unseal (Key 3)
 $ export VAULT_TOKEN=(Root token)
 # Required to run Spring Cloud Vault tests after manual initialization
-$ vault token-create -id="00000000-0000-0000-0000-000000000000" -policy="root"
+$ vault token create -id="00000000-0000-0000-0000-000000000000" -policy="root"
 ----
 
 Spring Cloud Vault accesses different resources.

--- a/docs/src/main/asciidoc/spring-cloud-vault.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-vault.adoc
@@ -452,7 +452,7 @@ NOTE: Response Wrapping for token creation requires Vault 0.6.0 or higher.
 ====
 [source,shell]
 ----
-$ vault token-create -wrap-ttl="10m"
+$ vault token create -wrap-ttl="10m"
 Key                            Value
 ---                            -----
 wrapping_token:                397ccb93-ff6c-b17b-9389-380b01ca2645


### PR DESCRIPTION
Hi,
I was working through the examples and found that the "init", "unseal" and "token-create" commands had changed in the version of vault that I am using, v1.4.1 which has been out since April 2020. I was unable to locate in which version of vault that the init and unseal commands were made sub commands of operator, the release notes go back to 0.7.0 so I am assuming, quite some time.

How does the README.md get updated from these sources?

I am going to try and add support for another database (couchbase) after this so if you have any suggestions before I make a horrible mess...

Regards, Francis.