### PR TITLE
typo: correct typo in an exception message

### DIFF
--- a/spring-cloud-vault-config/src/main/java/org/springframework/cloud/vault/config/ClientAuthenticationFactory.java
+++ b/spring-cloud-vault-config/src/main/java/org/springframework/cloud/vault/config/ClientAuthenticationFactory.java
@@ -242,7 +242,7 @@ class ClientAuthenticationFactory {
 		}
 
 		throw new IllegalArgumentException(
-				"Cannot configure RoleId. Any of role-id, initial token, or initial toke and role name must be configured.");
+				"Cannot configure RoleId. Any of role-id, initial token, or initial token and role name must be configured.");
 	}
 
 	private static SecretId getSecretId(VaultProperties vaultProperties,


### PR DESCRIPTION
Hi, 
I have just found a small typo in an exception message and correct it.
Thanks.