### PR TITLE
Changes for Issue #451 to make more Azure auth properties configurable

### DIFF
--- a/docs/src/main/asciidoc/authentication.adoc
+++ b/docs/src/main/asciidoc/authentication.adoc
@@ -381,15 +381,21 @@ spring.cloud.vault:
     azure-msi:
         role: my-dev-role
         azure-path: azure
+        metadata-service: http://169.254.169.254/metadata/instance...
+        identity-token-service: http://169.254.169.254/metadata/identity...
 ----
 ====
 
 * `role` sets the name of the role against which the login is being attempted.
 * `azure-path` sets the path of the Azure mount to use
+* `metadata-service` sets the URI at which to access the instance metadata service
+* `identity-token-service` sets the URI at which to access the identity token service
 
-Azure MSI authentication fetches environmental details about the virtual machine (subscription Id, resource group, VM name) from the instance metadata service.
+Azure MSI authentication fetches environmental details about the virtual machine (subscription Id, resource group, VM name) from the instance metadata service. By default, Azure assumes your Vault server has Resource ID `https://vault.hashicorp.com`. To change this, set `spring.cloud.vault.azure-msi.identity-token-service`.
 
-See also: https://www.vaultproject.io/docs/auth/azure.html[Vault Documentation: Using the azure auth backend]
+See also: 
+* https://www.vaultproject.io/docs/auth/azure.html[Vault Documentation: Using the azure auth backend]
+* https://docs.microsoft.com/en-us/azure/virtual-machines/windows/instance-metadata-service[Azure Documentation: Azure Instance Metadata Service]
 
 [[vault.config.authentication.clientcert]]
 === TLS certificate authentication

--- a/spring-cloud-vault-config/src/main/java/org/springframework/cloud/vault/config/ClientAuthenticationFactory.java
+++ b/spring-cloud-vault-config/src/main/java/org/springframework/cloud/vault/config/ClientAuthenticationFactory.java
@@ -303,7 +303,10 @@ class ClientAuthenticationFactory {
 
 		Assert.hasText(azureMsi.getRole(), "Azure role (spring.cloud.vault.azure-msi.role) must not be empty");
 
-		AzureMsiAuthenticationOptions options = AzureMsiAuthenticationOptions.builder().role(azureMsi.getRole())
+		AzureMsiAuthenticationOptions options = AzureMsiAuthenticationOptions.builder() //
+				.role(azureMsi.getRole()).path(azureMsi.getAzurePath()) //
+				.instanceMetadataUri(azureMsi.getMetadataService()) //
+				.identityTokenServiceUri(azureMsi.getIdentityTokenService()) //
 				.build();
 
 		return new AzureMsiAuthentication(options, this.restOperations, this.externalRestOperations);

--- a/spring-cloud-vault-config/src/main/java/org/springframework/cloud/vault/config/VaultProperties.java
+++ b/spring-cloud-vault-config/src/main/java/org/springframework/cloud/vault/config/VaultProperties.java
@@ -26,6 +26,7 @@ import org.springframework.core.env.Environment;
 import org.springframework.core.io.Resource;
 import org.springframework.lang.Nullable;
 import org.springframework.util.StringUtils;
+import org.springframework.vault.authentication.AzureMsiAuthenticationOptions;
 import org.springframework.vault.authentication.LoginToken;
 import org.springframework.vault.core.lease.LeaseEndpoints;
 
@@ -666,6 +667,16 @@ public class VaultProperties implements EnvironmentAware {
 		 */
 		private String role = "";
 
+		/**
+		 * Instance metadata service URI
+		 */
+		private URI metadataService = AzureMsiAuthenticationOptions.DEFAULT_INSTANCE_METADATA_SERVICE_URI;
+
+		/**
+		 * Identity token service URI
+		 */
+		private URI identityTokenService = AzureMsiAuthenticationOptions.DEFAULT_IDENTITY_TOKEN_SERVICE_URI;
+
 		public String getAzurePath() {
 			return this.azurePath;
 		}
@@ -674,12 +685,28 @@ public class VaultProperties implements EnvironmentAware {
 			return this.role;
 		}
 
+		public URI getMetadataService() {
+			return metadataService;
+		}
+
+		public URI getIdentityTokenService() {
+			return identityTokenService;
+		}
+
 		public void setAzurePath(String azurePath) {
 			this.azurePath = azurePath;
 		}
 
 		public void setRole(String role) {
 			this.role = role;
+		}
+
+		public void setMetadataService(URI metadataService) {
+			this.metadataService = metadataService;
+		}
+
+		public void setIdentityTokenService(URI identityTokenService) {
+			this.identityTokenService = identityTokenService;
 		}
 
 	}


### PR DESCRIPTION
- Added some fields in `VaultProperties.java`: `AzureMsiProperties.identityTokenServic`e and `AzureMsiProperties.metadataService`. Used these names to follow conventions set [here](https://github.com/spring-projects/spring-vault/blob/master/spring-vault-core/src/main/java/org/springframework/vault/config/EnvironmentVaultConfiguration.java). Defaults remain the same.
- In `ClientAuthenticationFactory.java`, when building `AzureMsiAuthenticationOptions`, use those properties.
- Updated docs to indicate the ability to set `spring.cloud.vault.azure-msi.metadata`, `spring.cloud.vault.azure-msi.identity-token-service`