### PR TITLE
Issue 572

### DIFF
--- a/spring-cloud-vault-config-aws/src/main/java/org/springframework/cloud/vault/config/aws/AwsCredentialType.java
+++ b/spring-cloud-vault-config-aws/src/main/java/org/springframework/cloud/vault/config/aws/AwsCredentialType.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2013-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @author Kris Iyer
+ *
+ * Supported Aws credential types.
+ */
+package org.springframework.cloud.vault.config.aws;
+
+public enum AwsCredentialType {
+
+	iam_user, assumed_role, federation_token
+
+}

--- a/spring-cloud-vault-config-aws/src/main/java/org/springframework/cloud/vault/config/aws/VaultAwsProperties.java
+++ b/spring-cloud-vault-config-aws/src/main/java/org/springframework/cloud/vault/config/aws/VaultAwsProperties.java
@@ -24,6 +24,7 @@ import org.springframework.lang.Nullable;
  * Configuration properties for Vault using the AWS integration.
  *
  * @author Mark Paluch
+ * @author Kris Iyer
  */
 @ConfigurationProperties("spring.cloud.vault.aws")
 public class VaultAwsProperties implements VaultSecretBackendDescriptor {
@@ -45,6 +46,11 @@ public class VaultAwsProperties implements VaultSecretBackendDescriptor {
 	private String backend = "aws";
 
 	/**
+	 * aws credential type
+	 */
+	private AwsCredentialType credentialType = AwsCredentialType.iam_user;
+
+	/**
 	 * Target property for the obtained access key.
 	 */
 	private String accessKeyProperty = "cloud.aws.credentials.accessKey";
@@ -53,6 +59,11 @@ public class VaultAwsProperties implements VaultSecretBackendDescriptor {
 	 * Target property for the obtained secret key.
 	 */
 	private String secretKeyProperty = "cloud.aws.credentials.secretKey";
+
+	/**
+	 * Target property for the obtained secret key.
+	 */
+	private String sessionTokenKeyProperty = "cloud.aws.credentials.sessionToken";
 
 	@Override
 	public boolean isEnabled() {
@@ -95,6 +106,22 @@ public class VaultAwsProperties implements VaultSecretBackendDescriptor {
 
 	public void setSecretKeyProperty(String secretKeyProperty) {
 		this.secretKeyProperty = secretKeyProperty;
+	}
+
+	public AwsCredentialType getCredentialType() {
+		return credentialType;
+	}
+
+	public void setCredentialType(AwsCredentialType credentialType) {
+		this.credentialType = credentialType;
+	}
+
+	public String getSessionTokenKeyProperty() {
+		return sessionTokenKeyProperty;
+	}
+
+	public void setSessionTokenKeyProperty(String sessionTokenKeyProperty) {
+		this.sessionTokenKeyProperty = sessionTokenKeyProperty;
 	}
 
 }

--- a/spring-cloud-vault-config-aws/src/main/java/org/springframework/cloud/vault/config/aws/VaultConfigAwsBootstrapConfiguration.java
+++ b/spring-cloud-vault-config-aws/src/main/java/org/springframework/cloud/vault/config/aws/VaultConfigAwsBootstrapConfiguration.java
@@ -61,7 +61,7 @@ public class VaultConfigAwsBootstrapConfiguration {
 
 	@Bean
 	@ConditionalOnProperty(name = "spring.cloud.vault.aws.credential-type", havingValue = "federation_token")
-	public AwsStsSecretBackendMetadataFactory awsStsFederrationTokenSecretBackendMetadataFactory(
+	public AwsStsSecretBackendMetadataFactory awsStsFederationTokenSecretBackendMetadataFactory(
 			ApplicationContext context) {
 		return new AwsStsSecretBackendMetadataFactory();
 	}
@@ -132,19 +132,19 @@ public class VaultConfigAwsBootstrapConfiguration {
 	}
 
 	/**
-	 * {@link SecretBackendMetadataFactory} for AWS integration using with STS Assumed
-	 * Role {@link VaultAwsProperties}.
+	 * {@link LeasingSecretBackendMetadata} for AWS integration using with STS Role
+	 * {@link VaultAwsProperties}.
 	 */
 	public static class AwsStsSecretBackendMetadataFactory implements SecretBackendMetadataFactory<VaultAwsProperties> {
 
 		/**
-		 * Creates {@link SecretBackendMetadata} for a secret backend using
-		 * {@link VaultAwsProperties}. This accessor transforms Vault's username/password
-		 * property names to names provided with
+		 * Creates {@link LeasingSecretBackendMetadata} for a secret backend for AWS STS
+		 * using {@link VaultAwsProperties}. This accessor transforms Vault's
+		 * username/password property names to names provided with
 		 * {@link VaultAwsProperties#getAccessKeyProperty()} and
 		 * {@link VaultAwsProperties#getSecretKeyProperty()}.
 		 * @param properties must not be {@literal null}.
-		 * @return the {@link SecretBackendMetadata}
+		 * @return the {@link LeasingSecretBackendMetadata}
 		 */
 		static LeasingSecretBackendMetadata forAws(final VaultAwsProperties properties) {
 

--- a/spring-cloud-vault-config-aws/src/main/java/org/springframework/cloud/vault/config/aws/VaultConfigAwsBootstrapConfiguration.java
+++ b/spring-cloud-vault-config-aws/src/main/java/org/springframework/cloud/vault/config/aws/VaultConfigAwsBootstrapConfiguration.java
@@ -19,30 +19,51 @@ package org.springframework.cloud.vault.config.aws;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.cloud.vault.config.LeasingSecretBackendMetadata;
 import org.springframework.cloud.vault.config.PropertyNameTransformer;
 import org.springframework.cloud.vault.config.SecretBackendMetadata;
 import org.springframework.cloud.vault.config.SecretBackendMetadataFactory;
 import org.springframework.cloud.vault.config.VaultSecretBackendDescriptor;
+import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.util.Assert;
+import org.springframework.vault.core.lease.domain.RequestedSecret;
+import org.springframework.vault.core.lease.domain.RequestedSecret.Mode;
 import org.springframework.vault.core.util.PropertyTransformer;
 
 /**
  * Bootstrap configuration providing support for the AWS secret backend.
  *
  * @author Mark Paluch
+ * @author Kris Iyer
+ *
  */
 @Configuration(proxyBeanMethods = false)
 @EnableConfigurationProperties(VaultAwsProperties.class)
 public class VaultConfigAwsBootstrapConfiguration {
 
 	@Bean
-	@ConditionalOnMissingBean
+	@ConditionalOnProperty(name = "spring.cloud.vault.aws.credential-type", havingValue = "iam_user",
+			matchIfMissing = true)
 	public AwsSecretBackendMetadataFactory awsSecretBackendMetadataFactory() {
 		return new AwsSecretBackendMetadataFactory();
+	}
+
+	@Bean
+	@ConditionalOnProperty(name = "spring.cloud.vault.aws.credential-type", havingValue = "assumed_role")
+	public AwsStsSecretBackendMetadataFactory awsStsAssumedRoleSecretBackendMetadataFactory(
+			ApplicationContext context) {
+		return new AwsStsSecretBackendMetadataFactory();
+	}
+
+	@Bean
+	@ConditionalOnProperty(name = "spring.cloud.vault.aws.credential-type", havingValue = "federation_token")
+	public AwsStsSecretBackendMetadataFactory awsStsFederrationTokenSecretBackendMetadataFactory(
+			ApplicationContext context) {
+		return new AwsStsSecretBackendMetadataFactory();
 	}
 
 	/**
@@ -101,6 +122,89 @@ public class VaultConfigAwsBootstrapConfiguration {
 		@Override
 		public SecretBackendMetadata createMetadata(VaultAwsProperties backendDescriptor) {
 			return forAws(backendDescriptor);
+		}
+
+		@Override
+		public boolean supports(VaultSecretBackendDescriptor backendDescriptor) {
+			return backendDescriptor instanceof VaultAwsProperties;
+		}
+
+	}
+
+	/**
+	 * {@link SecretBackendMetadataFactory} for AWS integration using with STS Assumed
+	 * Role {@link VaultAwsProperties}.
+	 */
+	public static class AwsStsSecretBackendMetadataFactory implements SecretBackendMetadataFactory<VaultAwsProperties> {
+
+		/**
+		 * Creates {@link SecretBackendMetadata} for a secret backend using
+		 * {@link VaultAwsProperties}. This accessor transforms Vault's username/password
+		 * property names to names provided with
+		 * {@link VaultAwsProperties#getAccessKeyProperty()} and
+		 * {@link VaultAwsProperties#getSecretKeyProperty()}.
+		 * @param properties must not be {@literal null}.
+		 * @return the {@link SecretBackendMetadata}
+		 */
+		static LeasingSecretBackendMetadata forAws(final VaultAwsProperties properties) {
+
+			Assert.notNull(properties, "VaultAwsProperties must not be null");
+			Assert.isTrue(
+					(properties.getCredentialType().name().equals(AwsCredentialType.assumed_role.name())
+							|| properties.getCredentialType().name().equals(AwsCredentialType.federation_token.name())),
+					"Expect credential-type to be '" + AwsCredentialType.assumed_role.name() + "' or '"
+							+ AwsCredentialType.federation_token.name() + "'");
+
+			PropertyNameTransformer transformer = new PropertyNameTransformer();
+			transformer.addKeyTransformation("access_key", properties.getAccessKeyProperty());
+			transformer.addKeyTransformation("secret_key", properties.getSecretKeyProperty());
+			transformer.addKeyTransformation("security_token", properties.getSessionTokenKeyProperty());
+
+			return new LeasingSecretBackendMetadata() {
+
+				@Override
+				public String getName() {
+					return String.format("%s with Role %s", properties.getBackend(), properties.getRole());
+				}
+
+				@Override
+				public String getPath() {
+					return String.format("%s/sts/%s", properties.getBackend(), properties.getRole());
+				}
+
+				@Override
+				public PropertyTransformer getPropertyTransformer() {
+					return transformer;
+				}
+
+				@Override
+				public Map<String, String> getVariables() {
+
+					Map<String, String> variables = new HashMap<>();
+
+					variables.put("backend", properties.getBackend());
+					variables.put("key", String.format("sts/%s", properties.getRole()));
+
+					return variables;
+				}
+
+				@Override
+				public Mode getLeaseMode() {
+					return RequestedSecret.Mode.ROTATE;
+				}
+
+			};
+
+		}
+
+		@Override
+		public SecretBackendMetadata createMetadata(VaultAwsProperties backendDescriptor) {
+			if (backendDescriptor.getCredentialType().name().equalsIgnoreCase(AwsCredentialType.iam_user.name())) {
+				return AwsSecretBackendMetadataFactory.forAws(backendDescriptor);
+			}
+			else {
+				return AwsStsSecretBackendMetadataFactory.forAws(backendDescriptor);
+			}
 		}
 
 		@Override


### PR DESCRIPTION
- Adds a new enum for supported AWS credential types. Defaults to iam_user
- Updates to VaultAwsProperties to include credential type as well as session token for AWS STS.
-  creates AwsStsSecretBackendMetadataFactory with LeasingSecretBackendMetadata for AWS STS.

Fixes #572 