### PR TITLE
Retry mechanism

### DIFF
--- a/spring-cloud-vault-config/pom.xml
+++ b/spring-cloud-vault-config/pom.xml
@@ -59,6 +59,18 @@
 			<optional>true</optional>
 		</dependency>
 
+		<dependency>
+			<groupId>org.springframework.retry</groupId>
+			<artifactId>spring-retry</artifactId>
+			<optional>true</optional>
+		</dependency>
+
+		<dependency>
+			<groupId>org.aspectj</groupId>
+			<artifactId>aspectjweaver</artifactId>
+			<optional>true</optional>
+		</dependency>
+
 		<!-- HTTP Client Libraries -->
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>

--- a/spring-cloud-vault-config/src/main/java/org/springframework/cloud/vault/config/RetryableVaultTemplate.java
+++ b/spring-cloud-vault-config/src/main/java/org/springframework/cloud/vault/config/RetryableVaultTemplate.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2017-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.vault.config;
+
+import org.springframework.retry.annotation.Retryable;
+import org.springframework.vault.authentication.SessionManager;
+import org.springframework.vault.client.RestTemplateBuilder;
+import org.springframework.vault.core.VaultTemplate;
+import org.springframework.vault.support.VaultResponse;
+import org.springframework.vault.support.VaultResponseSupport;
+
+/**
+ *
+ * VaultTemplate extended with retry configuration
+ *
+ */
+class RetryableVaultTemplate extends VaultTemplate {
+
+	RetryableVaultTemplate(RestTemplateBuilder restTemplateBuilder, SessionManager sessionManager) {
+		super(restTemplateBuilder, sessionManager);
+	}
+
+	RetryableVaultTemplate(RestTemplateBuilder restTemplateBuilder) {
+		super(restTemplateBuilder);
+	}
+
+	@Retryable(interceptor = "vaultRetryInterceptor")
+	@Override
+	public VaultResponse read(final String path) {
+		return super.read(path);
+	}
+
+	@Retryable(interceptor = "vaultRetryInterceptor")
+	@Override
+	public <T> VaultResponseSupport<T> read(final String path, final Class<T> responseType) {
+		return super.read(path, responseType);
+	}
+
+}

--- a/spring-cloud-vault-config/src/main/java/org/springframework/cloud/vault/config/VaultProperties.java
+++ b/spring-cloud-vault-config/src/main/java/org/springframework/cloud/vault/config/VaultProperties.java
@@ -130,6 +130,8 @@ public class VaultProperties implements EnvironmentAware {
 
 	private Session session = new Session();
 
+	private Retry retry = new Retry();
+
 	/**
 	 * Application name for AppId authentication.
 	 */
@@ -348,6 +350,14 @@ public class VaultProperties implements EnvironmentAware {
 
 	public void setAuthentication(AuthenticationMethod authentication) {
 		this.authentication = authentication;
+	}
+
+	public Retry getRetry() {
+		return this.retry;
+	}
+
+	public void setRetry(Retry retry) {
+		this.retry = retry;
 	}
 
 	/**
@@ -1283,6 +1293,67 @@ public class VaultProperties implements EnvironmentAware {
 
 		public void setExpiryThreshold(Duration expiryThreshold) {
 			this.expiryThreshold = expiryThreshold;
+		}
+
+	}
+
+	/**
+	 * Vault retry configuration
+	 *
+	 * @since 3.0.2
+	 */
+	public static class Retry {
+
+		/**
+		 * Initial retry interval in milliseconds.
+		 */
+		long initialInterval = 1000;
+
+		/**
+		 * Multiplier for next interval.
+		 */
+		double multiplier = 1.1;
+
+		/**
+		 * Maximum interval for backoff.
+		 */
+		long maxInterval = 2000;
+
+		/**
+		 * Maximum number of attempts.
+		 */
+		int maxAttempts = 6;
+
+		public long getInitialInterval() {
+			return this.initialInterval;
+		}
+
+		public void setInitialInterval(long initialInterval) {
+			this.initialInterval = initialInterval;
+		}
+
+		public double getMultiplier() {
+			return this.multiplier;
+		}
+
+		public void setMultiplier(double multiplier) {
+			this.multiplier = multiplier;
+		}
+
+		public long getMaxInterval() {
+			return this.maxInterval;
+		}
+
+		public void setMaxInterval(long maxInterval) {
+			this.maxInterval = maxInterval;
+		}
+
+		public int getMaxAttempts() {
+			return this.maxAttempts;
+		}
+
+		public void setMaxAttempts(int maxAttempts) {
+			this.maxAttempts = maxAttempts;
 		}
 
 	}


### PR DESCRIPTION
Opening for discussion - I believe vault is critical enough infrastructure that clients should have a retry mechanism out of the box.

Relates to https://github.com/spring-projects/spring-vault/issues/504
and
https://github.com/spring-cloud/spring-cloud-vault/issues/236

Due to the similarities (both bootstrap property sources), default retry properties were set to match spring cloud config's defaults (https://cloud.spring.io/spring-cloud-config/multi/multi__spring_cloud_config_client.html#config-client-retry)

I have not added tests - I can/will do so once a maintainer indicates this PR on the right track and has potential to be merged.  

Thank you
