### PR TITLE
Add a token file authentication mechanism

### DIFF
--- a/docs/src/main/asciidoc/authentication.adoc
+++ b/docs/src/main/asciidoc/authentication.adoc
@@ -30,6 +30,32 @@ spring.cloud.vault:
 
 See also: https://www.vaultproject.io/docs/concepts/tokens.html[Vault Documentation: Tokens]
 
+[[vault.config.authentication.token-file]]
+=== Token File authentication
+
+An option to load a vault token from a file rather than the static declaration of the TOKEN authentication mechanism.
+This is particularly helpful for local development when using the Vault CLI to obtain a token. Once logged in to Vault
+via the Vault CLI, a file is placed in the user's home directory at `~/.vault-token`.
+
+.application.yml
+====
+[source,yaml]
+----
+spring.cloud.vault:
+    authentication: TOKEN_FILE
+    token-file:
+        location: file:\${user.home}/.vault-token
+----
+====
+
+* `authentication` setting this value to `TOKEN_FILE` selects the Token File authentication method
+* `location` sets the path to a file containing a vault token. Defaults to `file:${user.home}/.vault-token` which is the location where the vault CLI places the token
+
+See also:
+
+* https://www.vaultproject.io/docs/commands/login[Vault Documentation: CLI login]
+* https://www.vaultproject.io/docs/commands/token-helper[Vault Documentation: CLI default to ~/.vault-token]
+
 [[vault.config.authentication.vault-agent]]
 === Vault Agent authentication
 

--- a/spring-cloud-vault-config/src/main/java/org/springframework/cloud/vault/config/ClientAuthenticationFactory.java
+++ b/spring-cloud-vault-config/src/main/java/org/springframework/cloud/vault/config/ClientAuthenticationFactory.java
@@ -406,8 +406,7 @@ class ClientAuthenticationFactory {
 
 		Resource tokenFileResource = tokenFile.getLocation();
 
-		// Default token file to ~/.vault-token because that's where the vault CLI will
-		// place it
+		// Default token file to ~/.vault-token because that's where the vault CLI will place it
 		if (Objects.isNull(tokenFileResource)) {
 			tokenFileResource = new FileSystemResource(Paths.get(System.getProperty("user.home"), ".vault-token"));
 		}

--- a/spring-cloud-vault-config/src/main/java/org/springframework/cloud/vault/config/VaultProperties.java
+++ b/spring-cloud-vault-config/src/main/java/org/springframework/cloud/vault/config/VaultProperties.java
@@ -126,6 +126,8 @@ public class VaultProperties implements EnvironmentAware {
 
 	private PcfProperties pcf = new PcfProperties();
 
+	private TokenFileProperties tokenFile = new TokenFileProperties();
+
 	private Ssl ssl = new Ssl();
 
 	private Config config = new Config();
@@ -312,6 +314,14 @@ public class VaultProperties implements EnvironmentAware {
 		this.pcf = pcf;
 	}
 
+	public TokenFileProperties getTokenFile() {
+		return this.tokenFile;
+	}
+
+	public void setTokenFile(TokenFileProperties tokenFile) {
+		this.tokenFile = tokenFile;
+	}
+
 	public Ssl getSsl() {
 		return this.ssl;
 	}
@@ -357,7 +367,7 @@ public class VaultProperties implements EnvironmentAware {
 	 */
 	public enum AuthenticationMethod {
 
-		APPID, APPROLE, AWS_EC2, AWS_IAM, AZURE_MSI, CERT, CUBBYHOLE, GCP_GCE, GCP_IAM, KUBERNETES, NONE, PCF, TOKEN;
+		APPID, APPROLE, AWS_EC2, AWS_IAM, AZURE_MSI, CERT, CUBBYHOLE, GCP_GCE, GCP_IAM, KUBERNETES, NONE, PCF, TOKEN, TOKEN_FILE
 
 	}
 
@@ -988,6 +998,28 @@ public class VaultProperties implements EnvironmentAware {
 
 		public void setInstanceKey(@Nullable Resource instanceKey) {
 			this.instanceKey = instanceKey;
+		}
+
+	}
+
+	/**
+	 * TOKEN_FILE properties.
+	 */
+	public static class TokenFileProperties {
+
+		/**
+		 * Path to the file containing a vault token. Defaults to ~/.vault-token .
+		 */
+		@Nullable
+		private Resource location;
+
+		@Nullable
+		public Resource getLocation() {
+			return this.location;
+		}
+
+		public void setLocation(@Nullable Resource location) {
+			this.location = location;
 		}
 
 	}

--- a/spring-cloud-vault-config/src/test/java/org/springframework/cloud/vault/config/ClientAuthenticationFactoryUnitTests.java
+++ b/spring-cloud-vault-config/src/test/java/org/springframework/cloud/vault/config/ClientAuthenticationFactoryUnitTests.java
@@ -24,6 +24,7 @@ import org.springframework.vault.authentication.AppRoleAuthenticationOptions.Rol
 import org.springframework.vault.authentication.AppRoleAuthenticationOptions.SecretId;
 import org.springframework.vault.authentication.ClientAuthentication;
 import org.springframework.vault.authentication.PcfAuthentication;
+import org.springframework.vault.authentication.TokenAuthentication;
 import org.springframework.vault.support.VaultToken;
 import org.springframework.web.client.RestTemplate;
 
@@ -163,4 +164,16 @@ public class ClientAuthenticationFactoryUnitTests {
 		assertThat(clientAuthentication).isInstanceOf(PcfAuthentication.class);
 	}
 
+	@Test
+	public void shouldSupportTokenFileAuthentication() {
+
+		VaultProperties properties = new VaultProperties();
+		properties.setAuthentication(VaultProperties.AuthenticationMethod.TOKEN_FILE);
+		properties.getTokenFile().setLocation(new ClassPathResource("bootstrap.yml"));
+
+		ClientAuthentication clientAuthentication = new ClientAuthenticationFactory(properties, new RestTemplate(),
+				new RestTemplate()).createClientAuthentication();
+
+		assertThat(clientAuthentication).isInstanceOf(TokenAuthentication.class);
+	}
 }


### PR DESCRIPTION
Add an authentication mechanism to load a vault token from a file rather than the static declaration of the TOKEN authentication mechanism.

This is particularly helpful for local development when using the Vault CLI to obtain a token. Once logged in to Vault
via the Vault CLI, by default a file is placed in the user's home directory at `~/.vault-token` which contains the vault token. Rather than copying that file to a local variable or exporting an environment variable and restarting shells or development environments, just use the provided file to retrieve the token and run/test application.

More unit tests are needed, but I could use some pointers.

Would love to see about adding to a 3.0.x patch release in addition to the 3.1.0 mainline.