### PR TITLE
Add usage of spring.cloud.vault.reactive.enabled property in VaultConfigDataLoader

### DIFF
--- a/spring-cloud-vault-config/src/main/java/org/springframework/cloud/vault/config/VaultConfigDataLoader.java
+++ b/spring-cloud-vault-config/src/main/java/org/springframework/cloud/vault/config/VaultConfigDataLoader.java
@@ -127,7 +127,7 @@ public class VaultConfigDataLoader implements ConfigDataLoader<VaultConfigLocati
 
 		registerImperativeInfrastructure(bootstrap, vaultProperties);
 
-		if (REGISTER_REACTIVE_INFRASTRUCTURE) {
+		if (REGISTER_REACTIVE_INFRASTRUCTURE && vaultProperties.getReactive().isEnabled()) {
 			registerReactiveInfrastructure(bootstrap, vaultProperties);
 		}
 
@@ -191,7 +191,7 @@ public class VaultConfigDataLoader implements ConfigDataLoader<VaultConfigLocati
 
 			infra.registerClientAuthentication();
 
-			if (!REGISTER_REACTIVE_INFRASTRUCTURE) {
+			if (!REGISTER_REACTIVE_INFRASTRUCTURE || !vaultProperties.getReactive().isEnabled()) {
 				infra.registerVaultSessionManager();
 			}
 

--- a/spring-cloud-vault-config/src/main/java/org/springframework/cloud/vault/config/VaultProperties.java
+++ b/spring-cloud-vault-config/src/main/java/org/springframework/cloud/vault/config/VaultProperties.java
@@ -82,6 +82,11 @@ public class VaultProperties implements EnvironmentAware {
 	@Nullable
 	private String namespace;
 
+    /**
+     * Reactive properties
+     */
+    private Reactive reactive = new Reactive();
+
 	/**
 	 * Discovery properties.
 	 */
@@ -198,6 +203,14 @@ public class VaultProperties implements EnvironmentAware {
 	public void setNamespace(@Nullable String namespace) {
 		this.namespace = namespace;
 	}
+
+    public Reactive getReactive() {
+        return this.reactive;
+    }
+
+    public void setReactive(Reactive reactive) {
+        this.reactive = reactive;
+    }
 
 	public Discovery getDiscovery() {
 		return this.discovery;
@@ -360,6 +373,24 @@ public class VaultProperties implements EnvironmentAware {
 		APPID, APPROLE, AWS_EC2, AWS_IAM, AZURE_MSI, CERT, CUBBYHOLE, GCP_GCE, GCP_IAM, KUBERNETES, NONE, PCF, TOKEN;
 
 	}
+
+    /**
+     * Reactive properties.
+     */
+    public static class Reactive {
+        /**
+         * Flag to indicate that reactive discovery is enabled
+         */
+        private boolean enabled = true;
+
+        public boolean isEnabled() {
+            return this.enabled;
+        }
+
+        public void setEnabled(boolean enabled) {
+            this.enabled = enabled;
+        }
+    }
 
 	/**
 	 * Discovery properties.


### PR DESCRIPTION
Addition that makes the enablement of reactive infrastructure in VaultConfigDataLoader to take into account the value of the spring.cloud.vault.reactive.enabled property

fix #619