### PR TITLE
Fix spring.cloud.vault.kv.profiles precedence over application profiles

### DIFF
--- a/spring-cloud-vault-config/src/main/java/org/springframework/cloud/vault/config/VaultConfigDataLocationResolver.java
+++ b/spring-cloud-vault-config/src/main/java/org/springframework/cloud/vault/config/VaultConfigDataLocationResolver.java
@@ -42,6 +42,8 @@ import org.springframework.vault.core.util.PropertyTransformer;
 import org.springframework.vault.core.util.PropertyTransformers;
 import org.springframework.web.util.UriComponents;
 import org.springframework.web.util.UriComponentsBuilder;
+import org.springframework.core.ResolvableType;
+import org.springframework.boot.context.properties.bind.Bindable;
 
 /**
  * {@link ConfigDataLocationResolver} for Vault resolving {@link VaultConfigLocation}
@@ -194,7 +196,8 @@ public class VaultConfigDataLocationResolver implements ConfigDataLocationResolv
 		kvProperties.setApplicationName(binder.bind("spring.cloud.vault.kv.application-name", String.class)
 				.orElseGet(() -> binder.bind("spring.cloud.vault.application-name", String.class)
 						.orElseGet(() -> binder.bind("spring.application.name", String.class).orElse(""))));
-		kvProperties.setProfiles(profiles.getActive());
+		kvProperties.setProfiles(binder.bind("spring.cloud.vault.kv.profiles", Bindable.listOf(String.class))
+				.orElseGet(profiles::getActive));
 
 		return kvProperties;
 	}

--- a/spring-cloud-vault-config/src/test/java/org/springframework/cloud/vault/config/VaultConfigDataLocationResolverUnitTests.java
+++ b/spring-cloud-vault-config/src/test/java/org/springframework/cloud/vault/config/VaultConfigDataLocationResolverUnitTests.java
@@ -28,6 +28,8 @@ import org.springframework.boot.context.config.ConfigDataLocation;
 import org.springframework.boot.context.config.ConfigDataLocationResolverContext;
 import org.springframework.boot.context.config.Profiles;
 import org.springframework.boot.context.properties.bind.Binder;
+import org.springframework.boot.context.properties.source.ConfigurationPropertySource;
+import org.springframework.core.env.MapPropertySource;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
@@ -119,6 +121,22 @@ public class VaultConfigDataLocationResolverUnitTests {
 		assertThat(locations).hasSize(1);
 		assertThat(locations.get(0).getSecretBackendMetadata().getPropertyTransformer()
 				.transformProperties(Collections.singletonMap("key", "value"))).containsEntry("key", "value");
+	}
+
+	@Test
+	public void kvProfilesPropertyPrecedenceShouldBeRespected() {
+
+		VaultConfigDataLocationResolver resolver = new VaultConfigDataLocationResolver();
+
+		when(this.profilesMock.getActive()).thenReturn(Arrays.asList("a", "b"));
+		when(this.contextMock.getBinder()).thenReturn(new Binder(ConfigurationPropertySource.from(
+				new MapPropertySource("test",
+						Collections.singletonMap("spring.cloud.vault.kv.profiles", "c, d, e")))
+		));
+
+		assertThat(
+				resolver.resolveProfileSpecific(this.contextMock, ConfigDataLocation.of("vault://"), this.profilesMock))
+				.hasSize(4);
 	}
 
 }


### PR DESCRIPTION
Closes gh-630

Ideally it would be great if this fix could be included in 3.1.x, let me know if you want me to rebase on that branch instead of main.