### PR TITLE
Update VaultConfigDataLocationResolver to not override kv.profiles

### DIFF
--- a/spring-cloud-vault-config/src/main/java/org/springframework/cloud/vault/config/VaultConfigDataLocationResolver.java
+++ b/spring-cloud-vault-config/src/main/java/org/springframework/cloud/vault/config/VaultConfigDataLocationResolver.java
@@ -194,7 +194,9 @@ public class VaultConfigDataLocationResolver implements ConfigDataLocationResolv
 		kvProperties.setApplicationName(binder.bind("spring.cloud.vault.kv.application-name", String.class)
 				.orElseGet(() -> binder.bind("spring.cloud.vault.application-name", String.class)
 						.orElseGet(() -> binder.bind("spring.application.name", String.class).orElse(""))));
-		kvProperties.setProfiles(profiles.getActive());
+		if (kvProperties.profiles == null) {
+			kvProperties.setProfiles(profiles.getActive());
+		}
 
 		return kvProperties;
 	}


### PR DESCRIPTION
Current implementation overrides any profiles set through `spring.cloud.vault.kv.profiles` with the currently active profile, which is possibly unwanted behavior and prevents fine grained configuration.