### PR TITLE
Adjust auto-configuration to register at most one Vault health indicator

### DIFF
--- a/spring-cloud-vault-config/src/main/java/org/springframework/cloud/vault/config/VaultHealthIndicatorAutoConfiguration.java
+++ b/spring-cloud-vault-config/src/main/java/org/springframework/cloud/vault/config/VaultHealthIndicatorAutoConfiguration.java
@@ -30,7 +30,7 @@ import org.springframework.context.annotation.Import;
  * {@link org.springframework.boot.autoconfigure.EnableAutoConfiguration
  * Auto-configuration} for Vault providing beans for the application context.
  *
- * @author Mark Paluch
+ * @author Mark Paluch, Rastislav Zlacky
  * @since 2.0
  */
 @Configuration(proxyBeanMethods = false)
@@ -39,7 +39,7 @@ import org.springframework.context.annotation.Import;
 @ConditionalOnProperty(name = "spring.cloud.vault.enabled", matchIfMissing = true)
 @AutoConfigureBefore(HealthContributorAutoConfiguration.class)
 @AutoConfigureAfter({ VaultAutoConfiguration.class, VaultReactiveAutoConfiguration.class })
-@Import({ VaultHealthIndicatorConfiguration.class, VaultReactiveHealthIndicatorConfiguration.class })
+@Import({ VaultReactiveHealthIndicatorConfiguration.class, VaultHealthIndicatorConfiguration.class })
 public class VaultHealthIndicatorAutoConfiguration {
 
 }

--- a/spring-cloud-vault-config/src/main/java/org/springframework/cloud/vault/config/VaultReactiveHealthIndicatorConfiguration.java
+++ b/spring-cloud-vault-config/src/main/java/org/springframework/cloud/vault/config/VaultReactiveHealthIndicatorConfiguration.java
@@ -32,7 +32,7 @@ import org.springframework.vault.core.ReactiveVaultOperations;
 /**
  * Configuration for {@link VaultReactiveHealthIndicator}.
  *
- * @author Mark Paluch
+ * @author Mark Paluch, Rastislav Zlacky
  * @since 2.0
  */
 @Configuration(proxyBeanMethods = false)
@@ -47,9 +47,9 @@ class VaultReactiveHealthIndicatorConfiguration
 		this.reactiveVaultTemplates = reactiveVaultTemplates;
 	}
 
-	@Bean
-	@ConditionalOnMissingBean(name = { "vaultReactiveHealthIndicator" })
-	ReactiveHealthContributor vaultReactiveHealthIndicator() {
+	@Bean(name = { "vaultHealthIndicator", "vaultReactiveHealthIndicator" })
+	@ConditionalOnMissingBean(name = { "vaultHealthIndicator" })
+	ReactiveHealthContributor vaultHealthIndicator() {
 		return createContributor(this.reactiveVaultTemplates);
 	}
 

--- a/spring-cloud-vault-config/src/test/java/org/springframework/cloud/vault/config/VaultHealthIndicatorAutoConfigurationTests.java
+++ b/spring-cloud-vault-config/src/test/java/org/springframework/cloud/vault/config/VaultHealthIndicatorAutoConfigurationTests.java
@@ -30,7 +30,7 @@ import static org.mockito.Mockito.mock;
 /**
  * Unit tests for {@link VaultHealthIndicatorAutoConfiguration}.
  *
- * @author Mark Paluch
+ * @author Mark Paluch, Rastislav Zlacky
  */
 class VaultHealthIndicatorAutoConfigurationTests {
 
@@ -62,6 +62,17 @@ class VaultHealthIndicatorAutoConfigurationTests {
 
 	}
 
+	@Test
+	void shouldConfigureSingleHealthIndicator() {
+
+		this.contextRunner.withUserConfiguration(ImperativeConfiguration.class, ReactiveConfiguration.class)
+				.run(context -> {
+					assertThat(context).hasBean("vaultHealthIndicator")
+							.hasSingleBean(VaultReactiveHealthIndicator.class)
+							.doesNotHaveBean(VaultHealthIndicator.class);
+				});
+	}
+
 	static class ImperativeConfiguration {
 
 		@Bean
@@ -74,7 +85,7 @@ class VaultHealthIndicatorAutoConfigurationTests {
 	static class ReactiveConfiguration {
 
 		@Bean
-		ReactiveVaultOperations vaultOperations() {
+		ReactiveVaultOperations reactiveVaultOperations() {
 			return mock(ReactiveVaultOperations.class);
 		}
 


### PR DESCRIPTION
Adjust auto-configuration to register at most one Vault health indicator instead of both - reactive and imperative. Fixes gh-676