### PR TITLE
Fix typo in integration tests Javadoc

### DIFF
--- a/spring-cloud-vault-config-aws/src/test/java/org/springframework/cloud/vault/config/aws/VaultConfigAwsTests.java
+++ b/spring-cloud-vault-config-aws/src/test/java/org/springframework/cloud/vault/config/aws/VaultConfigAwsTests.java
@@ -39,7 +39,7 @@ import static org.junit.Assume.assumeTrue;
 /**
  * Integration tests using the aws secret backend. In case this test should fail because
  * of SSL make sure you run the test within the
- * spring-cloud-vault-config/spring-cloud-vault-config directory as the keystore is
+ * spring-cloud-vault/spring-cloud-vault-config directory as the keystore is
  * referenced with {@code ../work/keystore.jks}.
  *
  * <p>

--- a/spring-cloud-vault-config-consul/src/test/java/org/springframework/cloud/vault/config/consul/VaultConfigConsulTests.java
+++ b/spring-cloud-vault-config-consul/src/test/java/org/springframework/cloud/vault/config/consul/VaultConfigConsulTests.java
@@ -53,7 +53,7 @@ import static org.junit.Assume.assumeTrue;
 /**
  * Integration tests using the consul secret backend. In case this test should fail
  * because of SSL make sure you run the test within the
- * spring-cloud-vault-config/spring-cloud-vault-config directory as the keystore is
+ * spring-cloud-vault/spring-cloud-vault-config directory as the keystore is
  * referenced with {@code ../work/keystore.jks}.
  *
  * @author Mark Paluch

--- a/spring-cloud-vault-config-databases/src/test/java/org/springframework/cloud/vault/config/databases/VaultConfigCassandraTests.java
+++ b/spring-cloud-vault-config-databases/src/test/java/org/springframework/cloud/vault/config/databases/VaultConfigCassandraTests.java
@@ -41,7 +41,7 @@ import static org.junit.Assume.assumeTrue;
 /**
  * Integration tests using the cassandra secret backend. In case this test should fail
  * because of SSL make sure you run the test within the
- * spring-cloud-vault-config/spring-cloud-vault-config directory as the keystore is
+ * spring-cloud-vault/spring-cloud-vault-config directory as the keystore is
  * referenced with {@code ../work/keystore.jks}.
  *
  * @author Mark Paluch

--- a/spring-cloud-vault-config-databases/src/test/java/org/springframework/cloud/vault/config/databases/VaultConfigCouchbaseDatabaseTests.java
+++ b/spring-cloud-vault-config-databases/src/test/java/org/springframework/cloud/vault/config/databases/VaultConfigCouchbaseDatabaseTests.java
@@ -44,7 +44,7 @@ import static org.junit.Assume.assumeTrue;
 /**
  * Integration tests using the database secret backend. In case this test should fail
  * because of SSL make sure you run the test within the
- * spring-cloud-vault-config/spring-cloud-vault-config directory as the keystore is
+ * spring-cloud-vault/spring-cloud-vault-config directory as the keystore is
  * referenced with {@code ../work/keystore.jks}.
  *
  * @author Francis Hitchens

--- a/spring-cloud-vault-config-databases/src/test/java/org/springframework/cloud/vault/config/databases/VaultConfigCouchbaseTests.java
+++ b/spring-cloud-vault-config-databases/src/test/java/org/springframework/cloud/vault/config/databases/VaultConfigCouchbaseTests.java
@@ -42,7 +42,7 @@ import static org.junit.Assume.assumeTrue;
 /**
  * Integration tests using the couchbase secret backend. In case this test should fail
  * because of SSL make sure you run the test within the
- * spring-cloud-vault-config/spring-cloud-vault-config directory as the keystore is
+ * spring-cloud-vault/spring-cloud-vault-config directory as the keystore is
  * referenced with {@code ../work/keystore.jks}.
  *
  * @author Mark Paluch

--- a/spring-cloud-vault-config-databases/src/test/java/org/springframework/cloud/vault/config/databases/VaultConfigMongoTests.java
+++ b/spring-cloud-vault-config-databases/src/test/java/org/springframework/cloud/vault/config/databases/VaultConfigMongoTests.java
@@ -46,7 +46,7 @@ import static org.junit.Assume.assumeTrue;
 /**
  * Integration tests using the mongodb secret backend. In case this test should fail
  * because of SSL make sure you run the test within the
- * spring-cloud-vault-config/spring-cloud-vault-config directory as the keystore is
+ * spring-cloud-vault/spring-cloud-vault-config directory as the keystore is
  * referenced with {@code ../work/keystore.jks}.
  *
  * @author Mark Paluch

--- a/spring-cloud-vault-config-databases/src/test/java/org/springframework/cloud/vault/config/databases/VaultConfigMySqlDatabaseTests.java
+++ b/spring-cloud-vault-config-databases/src/test/java/org/springframework/cloud/vault/config/databases/VaultConfigMySqlDatabaseTests.java
@@ -41,7 +41,7 @@ import static org.junit.Assume.assumeTrue;
 /**
  * Integration tests using the database secret backend. In case this test should fail
  * because of SSL make sure you run the test within the
- * spring-cloud-vault-config/spring-cloud-vault-config directory as the keystore is
+ * spring-cloud-vault/spring-cloud-vault-config directory as the keystore is
  * referenced with {@code ../work/keystore.jks}.
  *
  * @author Mark Paluch

--- a/spring-cloud-vault-config-databases/src/test/java/org/springframework/cloud/vault/config/databases/VaultConfigMySqlDatabasesBootstrapTests.java
+++ b/spring-cloud-vault-config-databases/src/test/java/org/springframework/cloud/vault/config/databases/VaultConfigMySqlDatabasesBootstrapTests.java
@@ -44,7 +44,7 @@ import static org.junit.Assume.assumeTrue;
 /**
  * Integration tests using the database secret backend with multi-database support. In
  * case this test should fail because of SSL make sure you run the test within the
- * spring-cloud-vault-config/spring-cloud-vault-config directory as the keystore is
+ * spring-cloud-vault/spring-cloud-vault-config directory as the keystore is
  * referenced with {@code ../work/keystore.jks}.
  *
  * @author Mark Paluch

--- a/spring-cloud-vault-config-databases/src/test/java/org/springframework/cloud/vault/config/databases/VaultConfigMySqlDatabasesTests.java
+++ b/spring-cloud-vault-config-databases/src/test/java/org/springframework/cloud/vault/config/databases/VaultConfigMySqlDatabasesTests.java
@@ -41,7 +41,7 @@ import static org.junit.Assume.assumeTrue;
 /**
  * Integration tests using the database secret backend with multi-database support. In
  * case this test should fail because of SSL make sure you run the test within the
- * spring-cloud-vault-config/spring-cloud-vault-config directory as the keystore is
+ * spring-cloud-vault/spring-cloud-vault-config directory as the keystore is
  * referenced with {@code ../work/keystore.jks}.
  *
  * @author Mark Paluch

--- a/spring-cloud-vault-config-databases/src/test/java/org/springframework/cloud/vault/config/databases/VaultConfigMySqlTests.java
+++ b/spring-cloud-vault-config-databases/src/test/java/org/springframework/cloud/vault/config/databases/VaultConfigMySqlTests.java
@@ -42,7 +42,7 @@ import static org.junit.Assume.assumeTrue;
 /**
  * Integration tests using the mysql secret backend. In case this test should fail because
  * of SSL make sure you run the test within the
- * spring-cloud-vault-config/spring-cloud-vault-config directory as the keystore is
+ * spring-cloud-vault/spring-cloud-vault-config directory as the keystore is
  * referenced with {@code ../work/keystore.jks}.
  *
  * @author Mark Paluch

--- a/spring-cloud-vault-config-databases/src/test/java/org/springframework/cloud/vault/config/databases/VaultConfigPostgreSqlTests.java
+++ b/spring-cloud-vault-config-databases/src/test/java/org/springframework/cloud/vault/config/databases/VaultConfigPostgreSqlTests.java
@@ -44,7 +44,7 @@ import static org.junit.Assume.assumeTrue;
 /**
  * Integration tests using the postgresql secret backend. In case this test should fail
  * because of SSL make sure you run the test within the
- * spring-cloud-vault-config/spring-cloud-vault-config directory as the keystore is
+ * spring-cloud-vault/spring-cloud-vault-config directory as the keystore is
  * referenced with {@code ../work/keystore.jks}.
  *
  * @author Mark Paluch

--- a/spring-cloud-vault-config-rabbitmq/src/test/java/org/springframework/cloud/vault/config/rabbitmq/VaultConfigRabbitMqTests.java
+++ b/spring-cloud-vault-config-rabbitmq/src/test/java/org/springframework/cloud/vault/config/rabbitmq/VaultConfigRabbitMqTests.java
@@ -44,7 +44,7 @@ import static org.junit.Assume.assumeTrue;
 /**
  * Integration tests using the rabbitmq secret backend. In case this test should fail
  * because of SSL make sure you run the test within the
- * spring-cloud-vault-config/spring-cloud-vault-config directory as the keystore is
+ * spring-cloud-vault/spring-cloud-vault-config directory as the keystore is
  * referenced with {@code ../work/keystore.jks}.
  *
  * @author Mark Paluch

--- a/spring-cloud-vault-config/src/test/java/org/springframework/cloud/vault/config/ReactiveVaultOperationsTests.java
+++ b/spring-cloud-vault-config/src/test/java/org/springframework/cloud/vault/config/ReactiveVaultOperationsTests.java
@@ -40,7 +40,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * <p>
  * In case this test should fail because of SSL make sure you run the test within the
- * spring-cloud-vault-config/spring-cloud-vault-config directory as the keystore is
+ * spring-cloud-vault/spring-cloud-vault-config directory as the keystore is
  * referenced with {@code ../work/keystore.jks}.
  *
  * @author Mark Paluch

--- a/spring-cloud-vault-config/src/test/java/org/springframework/cloud/vault/config/VaultConfigAppIdTests.java
+++ b/spring-cloud-vault-config/src/test/java/org/springframework/cloud/vault/config/VaultConfigAppIdTests.java
@@ -41,7 +41,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * <p>
  * In case this test should fail because of SSL make sure you run the test within the
- * spring-cloud-vault-config/spring-cloud-vault-config directory as the keystore is
+ * spring-cloud-vault/spring-cloud-vault-config directory as the keystore is
  * referenced with {@code ../work/keystore.jks}.
  *
  * @author Mark Paluch

--- a/spring-cloud-vault-config/src/test/java/org/springframework/cloud/vault/config/VaultConfigAppRoleTests.java
+++ b/spring-cloud-vault-config/src/test/java/org/springframework/cloud/vault/config/VaultConfigAppRoleTests.java
@@ -42,7 +42,7 @@ import static org.junit.Assume.assumeTrue;
  *
  * <p>
  * In case this test should fail because of SSL make sure you run the test within the
- * spring-cloud-vault-config/spring-cloud-vault-config directory as the keystore is
+ * spring-cloud-vault/spring-cloud-vault-config directory as the keystore is
  * referenced with {@code ../work/keystore.jks}.
  *
  * @author Mark Paluch

--- a/spring-cloud-vault-config/src/test/java/org/springframework/cloud/vault/config/VaultConfigCubbyholeAuthenticationTests.java
+++ b/spring-cloud-vault-config/src/test/java/org/springframework/cloud/vault/config/VaultConfigCubbyholeAuthenticationTests.java
@@ -43,7 +43,7 @@ import static org.junit.Assume.assumeTrue;
  *
  * <p>
  * In case this test should fail because of SSL make sure you run the test within the
- * spring-cloud-vault-config/spring-cloud-vault-config directory as the keystore is
+ * spring-cloud-vault/spring-cloud-vault-config directory as the keystore is
  * referenced with {@code ../work/keystore.jks}.
  *
  * @author Mark Paluch

--- a/spring-cloud-vault-config/src/test/java/org/springframework/cloud/vault/config/VaultConfigDisabledTests.java
+++ b/spring-cloud-vault-config/src/test/java/org/springframework/cloud/vault/config/VaultConfigDisabledTests.java
@@ -39,7 +39,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * <p>
  * In case this test should fail because of SSL make sure you run the test within the
- * spring-cloud-vault-config/spring-cloud-vault-config directory as the keystore is
+ * spring-cloud-vault/spring-cloud-vault-config directory as the keystore is
  * referenced with {@code ../work/keystore.jks}.
  *
  * @author Mark Paluch

--- a/spring-cloud-vault-config/src/test/java/org/springframework/cloud/vault/config/VaultConfigKeyValueBackendDisabledTests.java
+++ b/spring-cloud-vault-config/src/test/java/org/springframework/cloud/vault/config/VaultConfigKeyValueBackendDisabledTests.java
@@ -37,7 +37,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * <p>
  * In case this test should fail because of SSL make sure you run the test within the
- * spring-cloud-vault-config/spring-cloud-vault-config directory as the keystore is
+ * spring-cloud-vault/spring-cloud-vault-config directory as the keystore is
  * referenced with {@code ../work/keystore.jks}.
  *
  * @author Mark Paluch

--- a/spring-cloud-vault-config/src/test/java/org/springframework/cloud/vault/config/VaultConfigLoaderSingleLocationTests.java
+++ b/spring-cloud-vault-config/src/test/java/org/springframework/cloud/vault/config/VaultConfigLoaderSingleLocationTests.java
@@ -41,7 +41,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * <p>
  * In case this test should fail because of SSL make sure you run the test within the
- * spring-cloud-vault-config/spring-cloud-vault-config directory as the keystore is
+ * spring-cloud-vault/spring-cloud-vault-config directory as the keystore is
  * referenced with {@code ../work/keystore.jks}.
  *
  * @author Mark Paluch

--- a/spring-cloud-vault-config/src/test/java/org/springframework/cloud/vault/config/VaultConfigLoaderTests.java
+++ b/spring-cloud-vault-config/src/test/java/org/springframework/cloud/vault/config/VaultConfigLoaderTests.java
@@ -45,7 +45,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * <p>
  * In case this test should fail because of SSL make sure you run the test within the
- * spring-cloud-vault-config/spring-cloud-vault-config directory as the keystore is
+ * spring-cloud-vault/spring-cloud-vault-config directory as the keystore is
  * referenced with {@code ../work/keystore.jks}.
  *
  * @author Mark Paluch

--- a/spring-cloud-vault-config/src/test/java/org/springframework/cloud/vault/config/VaultConfigTests.java
+++ b/spring-cloud-vault-config/src/test/java/org/springframework/cloud/vault/config/VaultConfigTests.java
@@ -44,7 +44,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * <p>
  * In case this test should fail because of SSL make sure you run the test within the
- * spring-cloud-vault-config/spring-cloud-vault-config directory as the keystore is
+ * spring-cloud-vault/spring-cloud-vault-config directory as the keystore is
  * referenced with {@code ../work/keystore.jks}.
  *
  * @author Mark Paluch

--- a/spring-cloud-vault-config/src/test/java/org/springframework/cloud/vault/config/VaultConfigTlsCertAuthenticationMountPathTests.java
+++ b/spring-cloud-vault-config/src/test/java/org/springframework/cloud/vault/config/VaultConfigTlsCertAuthenticationMountPathTests.java
@@ -42,7 +42,7 @@ import static org.springframework.cloud.vault.util.Settings.findWorkDir;
 /**
  * Integration test using config infrastructure with TLS certificate authentication. In
  * case this test should fail because of SSL make sure you run the test within the
- * spring-cloud-vault-config/spring-cloud-vault-config directory as the keystore is
+ * spring-cloud-vault/spring-cloud-vault-config directory as the keystore is
  * referenced with {@code ../work/keystore.jks}.
  *
  * @author Quincy Conduff

--- a/spring-cloud-vault-config/src/test/java/org/springframework/cloud/vault/config/VaultConfigTlsCertAuthenticationTests.java
+++ b/spring-cloud-vault-config/src/test/java/org/springframework/cloud/vault/config/VaultConfigTlsCertAuthenticationTests.java
@@ -42,7 +42,7 @@ import static org.springframework.cloud.vault.util.Settings.findWorkDir;
 /**
  * Integration test using config infrastructure with TLS certificate authentication. In
  * case this test should fail because of SSL make sure you run the test within the
- * spring-cloud-vault-config/spring-cloud-vault-config directory as the keystore is
+ * spring-cloud-vault/spring-cloud-vault-config directory as the keystore is
  * referenced with {@code ../work/keystore.jks}.
  *
  * @author Mark Paluch

--- a/spring-cloud-vault-config/src/test/java/org/springframework/cloud/vault/config/VaultConfigWithContextTests.java
+++ b/spring-cloud-vault-config/src/test/java/org/springframework/cloud/vault/config/VaultConfigWithContextTests.java
@@ -38,7 +38,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * <p>
  * In case this test should fail because of SSL make sure you run the test within the
- * spring-cloud-vault-config/spring-cloud-vault-config directory as the keystore is
+ * spring-cloud-vault/spring-cloud-vault-config directory as the keystore is
  * referenced with {@code ../work/keystore.jks}.
  *
  * @author Mark Paluch

--- a/spring-cloud-vault-config/src/test/java/org/springframework/cloud/vault/config/VaultConfigWithVaultConfigurerTests.java
+++ b/spring-cloud-vault-config/src/test/java/org/springframework/cloud/vault/config/VaultConfigWithVaultConfigurerTests.java
@@ -39,7 +39,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * <p>
  * In case this test should fail because of SSL make sure you run the test within the
- * spring-cloud-vault-config/spring-cloud-vault-config directory as the keystore is
+ * spring-cloud-vault/spring-cloud-vault-config directory as the keystore is
  * referenced with {@code ../work/keystore.jks}.
  *
  * @author Mark Paluch

--- a/spring-cloud-vault-config/src/test/java/org/springframework/cloud/vault/config/VaultVersionedKvBackendConfigTests.java
+++ b/spring-cloud-vault-config/src/test/java/org/springframework/cloud/vault/config/VaultVersionedKvBackendConfigTests.java
@@ -46,7 +46,7 @@ import static org.junit.Assume.assumeTrue;
  *
  * <p>
  * In case this test should fail because of SSL make sure you run the test within the
- * spring-cloud-vault-config/spring-cloud-vault-config directory as the keystore is
+ * spring-cloud-vault/spring-cloud-vault-config directory as the keystore is
  * referenced with {@code ../work/keystore.jks}.
  *
  * @author Mark Paluch


### PR DESCRIPTION
Fixing this Javadoc:

`In case this test should fail because of SSL make sure you run the test within the spring-cloud-vault-config/spring-cloud-vault-config directory as the keystore is referenced with {@code ../work/keystore.jks}.`